### PR TITLE
test: increase coverage from 21% to 29%

### DIFF
--- a/apps/web/src/test/unit/dateUtils.test.ts
+++ b/apps/web/src/test/unit/dateUtils.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getTodayLocalDate,
+  toLocalDate,
+  formatToDateString,
+  jsDateToDatabaseDayOfWeek,
+  databaseDayOfWeekToJsDate,
+  findNextOpenDay,
+  isClosedDay,
+} from "@/lib/dateUtils";
+
+describe("dateUtils", () => {
+  describe("getTodayLocalDate", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns today's date in YYYY-MM-DD format", () => {
+      vi.setSystemTime(new Date(2024, 5, 15)); // June 15, 2024
+      expect(getTodayLocalDate()).toBe("2024-06-15");
+    });
+
+    it("pads single-digit months with zero", () => {
+      vi.setSystemTime(new Date(2024, 0, 5)); // January 5, 2024
+      expect(getTodayLocalDate()).toBe("2024-01-05");
+    });
+
+    it("pads single-digit days with zero", () => {
+      vi.setSystemTime(new Date(2024, 11, 1)); // December 1, 2024
+      expect(getTodayLocalDate()).toBe("2024-12-01");
+    });
+  });
+
+  describe("toLocalDate", () => {
+    it("creates a date object from YYYY-MM-DD string", () => {
+      const date = toLocalDate("2024-06-15");
+      expect(date.getFullYear()).toBe(2024);
+      expect(date.getMonth()).toBe(5); // 0-indexed
+      expect(date.getDate()).toBe(15);
+    });
+
+    it("handles start of year", () => {
+      const date = toLocalDate("2024-01-01");
+      expect(date.getFullYear()).toBe(2024);
+      expect(date.getMonth()).toBe(0);
+      expect(date.getDate()).toBe(1);
+    });
+
+    it("handles end of year", () => {
+      const date = toLocalDate("2024-12-31");
+      expect(date.getFullYear()).toBe(2024);
+      expect(date.getMonth()).toBe(11);
+      expect(date.getDate()).toBe(31);
+    });
+  });
+
+  describe("formatToDateString", () => {
+    it("formats a date as YYYY-MM-DD", () => {
+      const date = new Date(2024, 5, 15);
+      expect(formatToDateString(date)).toBe("2024-06-15");
+    });
+
+    it("pads single-digit months and days", () => {
+      const date = new Date(2024, 0, 5);
+      expect(formatToDateString(date)).toBe("2024-01-05");
+    });
+  });
+
+  describe("jsDateToDatabaseDayOfWeek", () => {
+    it("converts Sunday (JS 0) to database 6", () => {
+      expect(jsDateToDatabaseDayOfWeek(0)).toBe(6);
+    });
+
+    it("converts Monday (JS 1) to database 0", () => {
+      expect(jsDateToDatabaseDayOfWeek(1)).toBe(0);
+    });
+
+    it("converts Tuesday (JS 2) to database 1", () => {
+      expect(jsDateToDatabaseDayOfWeek(2)).toBe(1);
+    });
+
+    it("converts Saturday (JS 6) to database 5", () => {
+      expect(jsDateToDatabaseDayOfWeek(6)).toBe(5);
+    });
+  });
+
+  describe("databaseDayOfWeekToJsDate", () => {
+    it("converts database 0 (Monday) to JS 1", () => {
+      expect(databaseDayOfWeekToJsDate(0)).toBe(1);
+    });
+
+    it("converts database 6 (Sunday) to JS 0", () => {
+      expect(databaseDayOfWeekToJsDate(6)).toBe(0);
+    });
+
+    it("converts database 5 (Saturday) to JS 6", () => {
+      expect(databaseDayOfWeekToJsDate(5)).toBe(6);
+    });
+  });
+
+  describe("findNextOpenDay", () => {
+    it("returns the next open day excluding today by default", () => {
+      // Create a shift map where Tuesday (db: 1) is open
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      for (let i = 0; i <= 6; i++) {
+        shiftDays.set(i, { is_open: i === 1, shift_ids: i === 1 ? ["shift-1"] : [] });
+      }
+
+      // From Monday (db: 0), next open day should be Tuesday
+      const result = findNextOpenDay("2024-06-17", shiftDays); // June 17, 2024 is Monday
+      expect(result).toBe("2024-06-18"); // Tuesday
+    });
+
+    it("includes today when includeToday is true", () => {
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      for (let i = 0; i <= 6; i++) {
+        shiftDays.set(i, { is_open: i === 0, shift_ids: i === 0 ? ["shift-1"] : [] }); // Monday open
+      }
+
+      // June 17, 2024 is Monday (db: 0), which is open
+      const result = findNextOpenDay("2024-06-17", shiftDays, true);
+      expect(result).toBe("2024-06-17"); // Same day
+    });
+
+    it("returns null when no open days within a week", () => {
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      for (let i = 0; i <= 6; i++) {
+        shiftDays.set(i, { is_open: false, shift_ids: [] }); // All closed
+      }
+
+      const result = findNextOpenDay("2024-06-17", shiftDays);
+      expect(result).toBe(null);
+    });
+
+    it("wraps around to next week correctly", () => {
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      for (let i = 0; i <= 6; i++) {
+        shiftDays.set(i, { is_open: i === 0, shift_ids: i === 0 ? ["shift-1"] : [] }); // Only Monday open
+      }
+
+      // June 18, 2024 is Tuesday. Next Monday is June 24
+      const result = findNextOpenDay("2024-06-18", shiftDays);
+      expect(result).toBe("2024-06-24");
+    });
+  });
+
+  describe("isClosedDay", () => {
+    it("returns true when day is not open", () => {
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      for (let i = 0; i <= 6; i++) {
+        shiftDays.set(i, { is_open: i !== 0, shift_ids: [] }); // Monday closed
+      }
+
+      // June 17, 2024 is Monday (db: 0)
+      expect(isClosedDay("2024-06-17", shiftDays)).toBe(true);
+    });
+
+    it("returns false when day is open", () => {
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      for (let i = 0; i <= 6; i++) {
+        shiftDays.set(i, { is_open: i === 0, shift_ids: i === 0 ? ["shift-1"] : [] }); // Monday open
+      }
+
+      expect(isClosedDay("2024-06-17", shiftDays)).toBe(false);
+    });
+
+    it("returns false when no config found for day", () => {
+      const shiftDays = new Map<number, { is_open: boolean; shift_ids: string[] }>();
+      // Empty map, no config for any day
+
+      expect(isClosedDay("2024-06-17", shiftDays)).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/test/unit/entitlements.test.ts
+++ b/apps/web/src/test/unit/entitlements.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getUserLimits } from "@/lib/entitlements";
+
+// Mock supabase for the async functions
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+describe("entitlements", () => {
+  describe("getUserLimits", () => {
+    it("returns correct limits for free plan", () => {
+      const limits = getUserLimits("free");
+      expect(limits.maxKitchens).toBe(1);
+      expect(limits.maxStationsPerKitchen).toBe(1);
+      expect(limits.canInviteAsOwner).toBe(false);
+    });
+
+    it("returns correct limits for pro plan", () => {
+      const limits = getUserLimits("pro");
+      expect(limits.maxKitchens).toBe(5);
+      expect(limits.maxStationsPerKitchen).toBe(Infinity);
+      expect(limits.canInviteAsOwner).toBe(true);
+    });
+  });
+
+  describe("async entitlements functions", () => {
+    let mockSupabase: ReturnType<typeof createMockSupabase>;
+
+    function createMockSupabase() {
+      const selectChain: Record<string, ReturnType<typeof vi.fn>> = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn(),
+        maybeSingle: vi.fn(),
+      };
+      return {
+        from: vi.fn(() => ({
+          select: vi.fn(() => selectChain),
+        })),
+        auth: {
+          getUser: vi.fn(),
+        },
+        selectChain,
+      };
+    }
+
+    beforeEach(async () => {
+      vi.resetModules();
+      mockSupabase = createMockSupabase();
+      vi.doMock("@/lib/supabase", () => ({
+        supabase: mockSupabase,
+      }));
+    });
+
+    it("getUserProfile returns profile data on success", async () => {
+      const mockProfile = { id: "user-1", plan: "pro" };
+      mockSupabase.selectChain.maybeSingle.mockResolvedValue({
+        data: mockProfile,
+        error: null,
+      });
+
+      const { getUserProfile } = await import("@/lib/entitlements");
+      const result = await getUserProfile("user-1");
+      expect(result).toEqual(mockProfile);
+    });
+
+    it("getUserProfile returns null on error", async () => {
+      mockSupabase.selectChain.maybeSingle.mockResolvedValue({
+        data: null,
+        error: { message: "Not found" },
+      });
+
+      const { getUserProfile } = await import("@/lib/entitlements");
+      const result = await getUserProfile("user-1");
+      expect(result).toBeNull();
+    });
+
+    it("getOwnedKitchenCount returns count on success", async () => {
+      const selectChain = {
+        eq: vi.fn().mockResolvedValue({ count: 3, error: null }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => selectChain),
+      });
+
+      const { getOwnedKitchenCount } = await import("@/lib/entitlements");
+      const result = await getOwnedKitchenCount("user-1");
+      expect(result).toBe(3);
+    });
+
+    it("getOwnedKitchenCount returns 0 on error", async () => {
+      const selectChain = {
+        eq: vi.fn().mockResolvedValue({ count: null, error: { message: "Error" } }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => selectChain),
+      });
+
+      const { getOwnedKitchenCount } = await import("@/lib/entitlements");
+      const result = await getOwnedKitchenCount("user-1");
+      expect(result).toBe(0);
+    });
+
+    it("getStationCount returns count on success", async () => {
+      const selectChain = {
+        eq: vi.fn().mockResolvedValue({ count: 5, error: null }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => selectChain),
+      });
+
+      const { getStationCount } = await import("@/lib/entitlements");
+      const result = await getStationCount("kitchen-1");
+      expect(result).toBe(5);
+    });
+
+    it("getStationCount returns 0 on error", async () => {
+      const selectChain = {
+        eq: vi.fn().mockResolvedValue({ count: null, error: { message: "Error" } }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => selectChain),
+      });
+
+      const { getStationCount } = await import("@/lib/entitlements");
+      const result = await getStationCount("kitchen-1");
+      expect(result).toBe(0);
+    });
+
+    it("getMembership returns membership on success", async () => {
+      const mockMembership = { id: "m-1", role: "owner", can_invite: true };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockMembership, error: null }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const { getMembership } = await import("@/lib/entitlements");
+      const result = await getMembership("user-1", "kitchen-1");
+      expect(result).toEqual(mockMembership);
+    });
+
+    it("getMembership returns null on error", async () => {
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: "Not found" } }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const { getMembership } = await import("@/lib/entitlements");
+      const result = await getMembership("user-1", "kitchen-1");
+      expect(result).toBeNull();
+    });
+
+    it("canGenerateInvite returns true for owner", async () => {
+      const mockMembership = { id: "m-1", role: "owner", can_invite: false };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockMembership, error: null }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const { canGenerateInvite } = await import("@/lib/entitlements");
+      const result = await canGenerateInvite("user-1", "kitchen-1");
+      expect(result).toBe(true);
+    });
+
+    it("canGenerateInvite returns true for member with can_invite", async () => {
+      const mockMembership = { id: "m-1", role: "member", can_invite: true };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockMembership, error: null }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const { canGenerateInvite } = await import("@/lib/entitlements");
+      const result = await canGenerateInvite("user-1", "kitchen-1");
+      expect(result).toBe(true);
+    });
+
+    it("canGenerateInvite returns false when no membership", async () => {
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: "Not found" } }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const { canGenerateInvite } = await import("@/lib/entitlements");
+      const result = await canGenerateInvite("user-1", "kitchen-1");
+      expect(result).toBe(false);
+    });
+
+    it("canGenerateInvite returns false for member without can_invite", async () => {
+      const mockMembership = { id: "m-1", role: "member", can_invite: false };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockMembership, error: null }),
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const { canGenerateInvite } = await import("@/lib/entitlements");
+      const result = await canGenerateInvite("user-1", "kitchen-1");
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/test/unit/stores/authStore.test.ts
+++ b/apps/web/src/test/unit/stores/authStore.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Create mocks using vi.hoisted so they're available when vi.mock runs
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: {
+    auth: {
+      getSession: vi.fn(),
+      signInWithPassword: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+    },
+  },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  setSentryUser: vi.fn(),
+}));
+
+vi.mock("@/lib", () => ({
+  supabase: mockSupabase,
+  setSentryUser: vi.fn(),
+}));
+
+// Import after mocking
+import { useAuthStore } from "@/stores/authStore";
+
+describe("authStore", () => {
+  const mockUser = {
+    id: "user-123",
+    email: "test@example.com",
+    user_metadata: { name: "Test User" },
+  };
+
+  const mockSession = {
+    access_token: "token",
+    user: mockUser,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the store state
+    useAuthStore.setState({
+      user: null,
+      session: null,
+      loading: true,
+      initialized: false,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has correct initial values", () => {
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(state.loading).toBe(true);
+      expect(state.initialized).toBe(false);
+    });
+  });
+
+  describe("initialize", () => {
+    it("fetches session and sets user on success", async () => {
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      await useAuthStore.getState().initialize();
+
+      const state = useAuthStore.getState();
+      expect(state.session).toEqual(mockSession);
+      expect(state.user).toEqual(mockUser);
+      expect(state.loading).toBe(false);
+      expect(state.initialized).toBe(true);
+    });
+
+    it("sets null user when no session", async () => {
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      await useAuthStore.getState().initialize();
+
+      const state = useAuthStore.getState();
+      expect(state.session).toBeNull();
+      expect(state.user).toBeNull();
+      expect(state.loading).toBe(false);
+      expect(state.initialized).toBe(true);
+    });
+
+    it("does not re-initialize if already initialized", async () => {
+      useAuthStore.setState({ initialized: true });
+
+      await useAuthStore.getState().initialize();
+
+      expect(mockSupabase.auth.getSession).not.toHaveBeenCalled();
+    });
+
+    it("sets up auth state change listener", async () => {
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
+
+      await useAuthStore.getState().initialize();
+
+      expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalled();
+    });
+  });
+
+  describe("signIn", () => {
+    it("signs in user and sets session on success", async () => {
+      mockSupabase.auth.signInWithPassword.mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+
+      const result = await useAuthStore.getState().signIn("test@example.com", "password");
+
+      expect(result.error).toBeUndefined();
+      const state = useAuthStore.getState();
+      expect(state.session).toEqual(mockSession);
+      expect(state.user).toEqual(mockUser);
+      expect(state.loading).toBe(false);
+    });
+
+    it("returns error message on failure", async () => {
+      mockSupabase.auth.signInWithPassword.mockResolvedValue({
+        data: { session: null, user: null },
+        error: { message: "Invalid credentials" },
+      });
+
+      const result = await useAuthStore.getState().signIn("test@example.com", "wrong");
+
+      expect(result.error).toBe("Invalid credentials");
+      expect(useAuthStore.getState().loading).toBe(false);
+    });
+
+    it("sets loading to true during sign in", async () => {
+      mockSupabase.auth.signInWithPassword.mockImplementation(() => {
+        expect(useAuthStore.getState().loading).toBe(true);
+        return Promise.resolve({
+          data: { session: mockSession, user: mockUser },
+          error: null,
+        });
+      });
+
+      await useAuthStore.getState().signIn("test@example.com", "password");
+    });
+  });
+
+  describe("signUp", () => {
+    it("signs up user and sets session on success", async () => {
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+
+      const result = await useAuthStore.getState().signUp("test@example.com", "password", "Test User");
+
+      expect(result.error).toBeUndefined();
+      const state = useAuthStore.getState();
+      expect(state.session).toEqual(mockSession);
+      expect(state.user).toEqual(mockUser);
+      expect(state.loading).toBe(false);
+    });
+
+    it("passes name in user metadata", async () => {
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: { session: mockSession, user: mockUser },
+        error: null,
+      });
+
+      await useAuthStore.getState().signUp("test@example.com", "password", "Test User");
+
+      expect(mockSupabase.auth.signUp).toHaveBeenCalledWith({
+        email: "test@example.com",
+        password: "password",
+        options: {
+          data: { name: "Test User" },
+        },
+      });
+    });
+
+    it("returns error message on failure", async () => {
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: { session: null, user: null },
+        error: { message: "Email already registered" },
+      });
+
+      const result = await useAuthStore.getState().signUp("test@example.com", "password", "Test");
+
+      expect(result.error).toBe("Email already registered");
+      expect(useAuthStore.getState().loading).toBe(false);
+    });
+
+    it("handles signup without immediate session (email confirmation required)", async () => {
+      mockSupabase.auth.signUp.mockResolvedValue({
+        data: { session: null, user: mockUser },
+        error: null,
+      });
+
+      const result = await useAuthStore.getState().signUp("test@example.com", "password", "Test");
+
+      expect(result.error).toBeUndefined();
+      expect(useAuthStore.getState().loading).toBe(false);
+    });
+  });
+
+  describe("signOut", () => {
+    it("clears user and session on sign out", async () => {
+      // Set initial authenticated state
+      useAuthStore.setState({
+        user: mockUser as never,
+        session: mockSession as never,
+      });
+
+      mockSupabase.auth.signOut.mockResolvedValue({ error: null });
+
+      await useAuthStore.getState().signOut();
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+    });
+
+    it("calls supabase signOut", async () => {
+      mockSupabase.auth.signOut.mockResolvedValue({ error: null });
+
+      await useAuthStore.getState().signOut();
+
+      expect(mockSupabase.auth.signOut).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/test/unit/stores/kitchenStore.test.ts
+++ b/apps/web/src/test/unit/stores/kitchenStore.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Create mocks using vi.hoisted so they're available when vi.mock runs
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/lib", () => ({
+  supabase: mockSupabase,
+  signInAnonymously: vi.fn(),
+  getTodayLocalDate: vi.fn(() => "2024-06-15"),
+}));
+
+// Import after mocking
+import { useKitchenStore } from "@/stores/kitchenStore";
+
+describe("kitchenStore", () => {
+  const mockKitchen = {
+    id: "kitchen-1",
+    name: "Test Kitchen",
+    owner_id: "user-1",
+    created_at: "2024-01-01",
+  };
+
+  const mockStations = [
+    { id: "s1", name: "Prep", kitchen_id: "kitchen-1", display_order: 0 },
+    { id: "s2", name: "Grill", kitchen_id: "kitchen-1", display_order: 1 },
+  ];
+
+  const mockMembership = {
+    id: "m1",
+    kitchen_id: "kitchen-1",
+    user_id: "user-1",
+    role: "owner",
+    can_invite: true,
+  };
+
+  const mockUser = {
+    id: "user-1",
+    email: "test@example.com",
+    user_metadata: { name: "Test User" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the store state
+    useKitchenStore.setState({
+      currentKitchen: null,
+      stations: [],
+      currentUser: null,
+      membership: null,
+      loading: false,
+      error: null,
+      selectedDate: "2024-06-15",
+      selectedShift: "",
+    });
+  });
+
+  describe("initial state", () => {
+    it("has correct initial values", () => {
+      const state = useKitchenStore.getState();
+      expect(state.currentKitchen).toBeNull();
+      expect(state.stations).toEqual([]);
+      expect(state.currentUser).toBeNull();
+      expect(state.membership).toBeNull();
+      expect(state.loading).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.selectedDate).toBe("2024-06-15");
+      expect(state.selectedShift).toBe("");
+    });
+  });
+
+  describe("setSelectedDate", () => {
+    it("updates selected date", () => {
+      useKitchenStore.getState().setSelectedDate("2024-07-20");
+      expect(useKitchenStore.getState().selectedDate).toBe("2024-07-20");
+    });
+  });
+
+  describe("setSelectedShift", () => {
+    it("updates selected shift", () => {
+      useKitchenStore.getState().setSelectedShift("dinner");
+      expect(useKitchenStore.getState().selectedShift).toBe("dinner");
+    });
+  });
+
+  describe("clearKitchen", () => {
+    it("resets all kitchen state", () => {
+      // Set some state first
+      useKitchenStore.setState({
+        currentKitchen: mockKitchen as never,
+        stations: mockStations as never,
+        currentUser: { id: "u1", displayName: "Test", isAnonymous: false },
+        membership: mockMembership as never,
+        error: "some error",
+        selectedDate: "2024-12-25",
+        selectedShift: "lunch",
+      });
+
+      useKitchenStore.getState().clearKitchen();
+
+      const state = useKitchenStore.getState();
+      expect(state.currentKitchen).toBeNull();
+      expect(state.stations).toEqual([]);
+      expect(state.currentUser).toBeNull();
+      expect(state.membership).toBeNull();
+      expect(state.error).toBeNull();
+      expect(state.selectedDate).toBe("2024-06-15"); // Reset to today
+      expect(state.selectedShift).toBe("");
+    });
+  });
+
+  describe("loadKitchen", () => {
+    it("loads kitchen data on success", async () => {
+      // Mock kitchen query
+      const kitchenChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockKitchen, error: null }),
+      };
+
+      // Mock stations query
+      const stationsChain = {
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: mockStations, error: null }),
+      };
+
+      // Mock membership query
+      const membershipChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockMembership, error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === "kitchens") {
+          return { select: vi.fn(() => kitchenChain) };
+        }
+        if (table === "stations") {
+          return { select: vi.fn(() => stationsChain) };
+        }
+        if (table === "kitchen_members") {
+          return { select: vi.fn(() => membershipChain) };
+        }
+        return {};
+      });
+
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: mockUser },
+        error: null,
+      });
+
+      await useKitchenStore.getState().loadKitchen("kitchen-1");
+
+      const state = useKitchenStore.getState();
+      expect(state.currentKitchen).toEqual(mockKitchen);
+      expect(state.stations).toEqual(mockStations);
+      expect(state.membership).toEqual(mockMembership);
+      expect(state.loading).toBe(false);
+    });
+
+    it("sets loading state during load", async () => {
+      const kitchenChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockImplementation(async () => {
+          expect(useKitchenStore.getState().loading).toBe(true);
+          return { data: mockKitchen, error: null };
+        }),
+      };
+
+      const stationsChain = {
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === "kitchens") {
+          return { select: vi.fn(() => kitchenChain) };
+        }
+        if (table === "stations") {
+          return { select: vi.fn(() => stationsChain) };
+        }
+        return { select: vi.fn(() => ({ eq: vi.fn().mockReturnThis(), single: vi.fn().mockResolvedValue({ data: null, error: null }) })) };
+      });
+
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      await useKitchenStore.getState().loadKitchen("kitchen-1");
+
+      expect(useKitchenStore.getState().loading).toBe(false);
+    });
+
+    it("sets error when kitchen not found", async () => {
+      const kitchenChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: "Not found" } }),
+      };
+
+      mockSupabase.from.mockReturnValue({ select: vi.fn(() => kitchenChain) });
+
+      await useKitchenStore.getState().loadKitchen("nonexistent");
+
+      expect(useKitchenStore.getState().error).toBe("Not found");
+      expect(useKitchenStore.getState().loading).toBe(false);
+    });
+
+    it("handles stations fetch error", async () => {
+      const kitchenChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockKitchen, error: null }),
+      };
+
+      const stationsChain = {
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: null, error: { message: "Stations error" } }),
+      };
+
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === "kitchens") {
+          return { select: vi.fn(() => kitchenChain) };
+        }
+        if (table === "stations") {
+          return { select: vi.fn(() => stationsChain) };
+        }
+        return {};
+      });
+
+      await useKitchenStore.getState().loadKitchen("kitchen-1");
+
+      expect(useKitchenStore.getState().error).toBe("Stations error");
+    });
+  });
+
+  describe("createKitchen", () => {
+    it("creates kitchen with stations and returns kitchen id", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: mockUser },
+        error: null,
+      });
+
+      // Mock all the database operations
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === "kitchens") {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({ data: mockKitchen, error: null }),
+              })),
+            })),
+          };
+        }
+        if (table === "kitchen_members") {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({ data: mockMembership, error: null }),
+              })),
+            })),
+          };
+        }
+        if (table === "stations") {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn().mockResolvedValue({ data: mockStations, error: null }),
+            })),
+          };
+        }
+        if (table === "kitchen_shifts") {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn().mockResolvedValue({
+                data: [
+                  { id: "sh1", name: "Breakfast" },
+                  { id: "sh2", name: "Lunch" },
+                  { id: "sh3", name: "Dinner" },
+                ],
+                error: null,
+              }),
+            })),
+          };
+        }
+        if (table === "kitchen_shift_days") {
+          return {
+            insert: vi.fn().mockResolvedValue({ error: null }),
+          };
+        }
+        if (table === "kitchen_units") {
+          return {
+            insert: vi.fn().mockResolvedValue({ error: null }),
+          };
+        }
+        return {};
+      });
+
+      const result = await useKitchenStore.getState().createKitchen("My Kitchen", ["Prep", "Grill"]);
+
+      expect(result.kitchenId).toBe("kitchen-1");
+      expect(result.error).toBeUndefined();
+
+      const state = useKitchenStore.getState();
+      expect(state.currentKitchen).toEqual(mockKitchen);
+      expect(state.stations).toEqual(mockStations);
+    });
+
+    it("returns error when not authenticated", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+        error: null,
+      });
+
+      const result = await useKitchenStore.getState().createKitchen("My Kitchen", ["Prep"]);
+
+      expect(result.error).toBe("Not authenticated");
+      expect(useKitchenStore.getState().error).toBe("Not authenticated");
+    });
+
+    it("handles kitchen creation error", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: mockUser },
+        error: null,
+      });
+
+      mockSupabase.from.mockReturnValue({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "Creation failed", code: "error" },
+            }),
+          })),
+        })),
+      });
+
+      const result = await useKitchenStore.getState().createKitchen("My Kitchen", ["Prep"]);
+
+      expect(result.error).toBe("Creation failed");
+    });
+  });
+
+  describe("joinKitchenViaInvite", () => {
+    const mockInviteLink = {
+      id: "invite-1",
+      token: "abc123",
+      kitchen_id: "kitchen-1",
+      kitchens: mockKitchen,
+      revoked: false,
+      expires_at: new Date(Date.now() + 86400000).toISOString(), // Tomorrow
+      use_count: 0,
+      max_uses: 10,
+    };
+
+    it("returns error for invalid invite link", async () => {
+      const inviteChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: "Not found" } }),
+      };
+
+      mockSupabase.from.mockReturnValue({ select: vi.fn(() => inviteChain) });
+
+      const result = await useKitchenStore.getState().joinKitchenViaInvite("invalid-token", "Guest");
+
+      expect(result.error).toBe("Invalid or expired invite link");
+    });
+
+    it("returns error for revoked invite link", async () => {
+      const revokedInvite = { ...mockInviteLink, revoked: true };
+      const inviteChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: revokedInvite, error: null }),
+      };
+
+      mockSupabase.from.mockReturnValue({ select: vi.fn(() => inviteChain) });
+
+      const result = await useKitchenStore.getState().joinKitchenViaInvite("abc123", "Guest");
+
+      expect(result.error).toBe("Invite link has expired");
+    });
+
+    it("returns error for expired invite link", async () => {
+      const expiredInvite = {
+        ...mockInviteLink,
+        expires_at: new Date(Date.now() - 86400000).toISOString(), // Yesterday
+      };
+      const inviteChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: expiredInvite, error: null }),
+      };
+
+      mockSupabase.from.mockReturnValue({ select: vi.fn(() => inviteChain) });
+
+      const result = await useKitchenStore.getState().joinKitchenViaInvite("abc123", "Guest");
+
+      expect(result.error).toBe("Invite link has expired");
+    });
+
+    it("returns error when max uses reached", async () => {
+      const maxedInvite = { ...mockInviteLink, use_count: 10, max_uses: 10 };
+      const inviteChain = {
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: maxedInvite, error: null }),
+      };
+
+      mockSupabase.from.mockReturnValue({ select: vi.fn(() => inviteChain) });
+
+      const result = await useKitchenStore.getState().joinKitchenViaInvite("abc123", "Guest");
+
+      expect(result.error).toBe("Invite link has reached max uses");
+    });
+  });
+});

--- a/apps/web/src/test/unit/stores/prepStore.test.ts
+++ b/apps/web/src/test/unit/stores/prepStore.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Create mocks using vi.hoisted so they're available when vi.mock runs
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock("@/lib", () => ({
+  supabase: mockSupabase,
+}));
+
+// Import after mocking
+import { usePrepStore } from "@/stores/prepStore";
+
+describe("prepStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the store state
+    usePrepStore.setState({
+      prepItems: [],
+      isInitialLoading: true,
+      isRefetching: false,
+      error: null,
+      currentContext: null,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has correct initial values", () => {
+      const state = usePrepStore.getState();
+      expect(state.prepItems).toEqual([]);
+      expect(state.isInitialLoading).toBe(true);
+      expect(state.isRefetching).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.currentContext).toBeNull();
+    });
+  });
+
+  describe("clearItems", () => {
+    it("resets items and context", () => {
+      // Set some state first
+      usePrepStore.setState({
+        prepItems: [{ id: "1" }] as never,
+        currentContext: { stationId: "s1", shiftDate: "2024-01-01", shiftId: "sh1" },
+        isInitialLoading: true,
+        isRefetching: true,
+      });
+
+      usePrepStore.getState().clearItems();
+
+      const state = usePrepStore.getState();
+      expect(state.prepItems).toEqual([]);
+      expect(state.currentContext).toBeNull();
+      expect(state.isInitialLoading).toBe(false);
+      expect(state.isRefetching).toBe(false);
+    });
+  });
+
+  describe("loadPrepItems", () => {
+    it("sets initial loading state on context change", async () => {
+      const orderChain = {
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        ...orderChain,
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const promise = usePrepStore.getState().loadPrepItems("station-1", "2024-01-01", "shift-1");
+
+      // Check loading state immediately
+      expect(usePrepStore.getState().isInitialLoading).toBe(true);
+
+      await promise;
+
+      expect(usePrepStore.getState().isInitialLoading).toBe(false);
+      expect(usePrepStore.getState().currentContext).toEqual({
+        stationId: "station-1",
+        shiftDate: "2024-01-01",
+        shiftId: "shift-1",
+      });
+    });
+
+    it("sets refetching state when context is same", async () => {
+      // Set initial context
+      usePrepStore.setState({
+        currentContext: { stationId: "station-1", shiftDate: "2024-01-01", shiftId: "shift-1" },
+        isInitialLoading: false,
+      });
+
+      const orderChain = {
+        order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        ...orderChain,
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      const promise = usePrepStore.getState().loadPrepItems("station-1", "2024-01-01", "shift-1");
+
+      // Should be refetching, not initial loading
+      expect(usePrepStore.getState().isRefetching).toBe(true);
+      expect(usePrepStore.getState().isInitialLoading).toBe(false);
+
+      await promise;
+    });
+
+    it("transforms prep items with joined data", async () => {
+      const mockData = [
+        {
+          id: "item-1",
+          station_id: "s1",
+          kitchen_items: { name: "Carrots" },
+          kitchen_units: { name: "lbs" },
+        },
+      ];
+      const orderChain = {
+        order: vi.fn().mockResolvedValue({ data: mockData, error: null }),
+      };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        ...orderChain,
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      await usePrepStore.getState().loadPrepItems("s1", "2024-01-01", "sh1");
+
+      const items = usePrepStore.getState().prepItems;
+      expect(items[0].description).toBe("Carrots");
+      expect(items[0].unit_name).toBe("lbs");
+    });
+
+    it("sets error on fetch failure", async () => {
+      const orderChain = {
+        order: vi.fn().mockResolvedValue({ data: null, error: { message: "Fetch failed" } }),
+      };
+      const eqChain = {
+        eq: vi.fn().mockReturnThis(),
+        ...orderChain,
+      };
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn(() => eqChain),
+      });
+
+      await usePrepStore.getState().loadPrepItems("s1", "2024-01-01", "sh1");
+
+      expect(usePrepStore.getState().error).toBe("Fetch failed");
+    });
+  });
+
+  describe("addPrepItem", () => {
+    it("adds item optimistically", async () => {
+      const mockInsertedItem = {
+        id: "real-id",
+        station_id: "s1",
+        kitchen_items: { name: "Onions" },
+        kitchen_units: { name: "kg" },
+      };
+      mockSupabase.from.mockReturnValue({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({ data: mockInsertedItem, error: null }),
+          })),
+        })),
+      });
+
+      const item = {
+        station_id: "s1",
+        shift_id: "sh1",
+        kitchen_item_id: "ki1",
+      };
+
+      const promise = usePrepStore.getState().addPrepItem(item, { description: "Onions" });
+
+      // Should have temp item immediately
+      const itemsDuringAdd = usePrepStore.getState().prepItems;
+      expect(itemsDuringAdd.length).toBe(1);
+      expect(itemsDuringAdd[0].id).toMatch(/^temp-/);
+
+      await promise;
+
+      // Should now have real item
+      const itemsAfterAdd = usePrepStore.getState().prepItems;
+      expect(itemsAfterAdd[0].id).toBe("real-id");
+    });
+
+    it("reverts on error", async () => {
+      mockSupabase.from.mockReturnValue({
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn().mockResolvedValue({ data: null, error: { message: "Insert failed" } }),
+          })),
+        })),
+      });
+
+      const item = {
+        station_id: "s1",
+        shift_id: "sh1",
+        kitchen_item_id: "ki1",
+      };
+
+      const result = await usePrepStore.getState().addPrepItem(item, { description: "Test" });
+
+      expect(result.error).toBe("Insert failed");
+      expect(usePrepStore.getState().prepItems).toEqual([]);
+    });
+  });
+
+  describe("cycleStatus", () => {
+    beforeEach(() => {
+      usePrepStore.setState({
+        prepItems: [
+          { id: "item-1", status: "pending", description: "Test" },
+          { id: "item-2", status: "in_progress", description: "Test 2" },
+          { id: "item-3", status: "complete", description: "Test 3" },
+        ] as never,
+      });
+    });
+
+    it("cycles pending to in_progress optimistically", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      });
+
+      const promise = usePrepStore.getState().cycleStatus("item-1");
+
+      // Optimistic update should happen immediately
+      expect(usePrepStore.getState().prepItems[0].status).toBe("in_progress");
+
+      await promise;
+    });
+
+    it("cycles in_progress to complete", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      });
+
+      await usePrepStore.getState().cycleStatus("item-2");
+
+      expect(usePrepStore.getState().prepItems[1].status).toBe("complete");
+    });
+
+    it("cycles complete to pending", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      });
+
+      await usePrepStore.getState().cycleStatus("item-3");
+
+      expect(usePrepStore.getState().prepItems[2].status).toBe("pending");
+    });
+
+    it("returns error when item not found", async () => {
+      const result = await usePrepStore.getState().cycleStatus("nonexistent");
+      expect(result.error).toBe("Item not found");
+    });
+
+    it("reverts on database error", async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: { message: "Update failed" } }),
+        })),
+      });
+
+      const result = await usePrepStore.getState().cycleStatus("item-1");
+
+      expect(result.error).toBe("Update failed");
+      // Should revert to original status
+      expect(usePrepStore.getState().prepItems[0].status).toBe("pending");
+    });
+  });
+
+  describe("deletePrepItem", () => {
+    beforeEach(() => {
+      usePrepStore.setState({
+        prepItems: [
+          { id: "item-1", description: "Test 1" },
+          { id: "item-2", description: "Test 2" },
+        ] as never,
+      });
+    });
+
+    it("deletes item optimistically", async () => {
+      mockSupabase.from.mockReturnValue({
+        delete: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      });
+
+      const promise = usePrepStore.getState().deletePrepItem("item-1");
+
+      // Optimistic delete
+      expect(usePrepStore.getState().prepItems.length).toBe(1);
+      expect(usePrepStore.getState().prepItems[0].id).toBe("item-2");
+
+      await promise;
+    });
+
+    it("returns error when item not found", async () => {
+      const result = await usePrepStore.getState().deletePrepItem("nonexistent");
+      expect(result.error).toBe("Item not found");
+    });
+
+    it("reverts on database error", async () => {
+      mockSupabase.from.mockReturnValue({
+        delete: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: { message: "Delete failed" } }),
+        })),
+      });
+
+      const result = await usePrepStore.getState().deletePrepItem("item-1");
+
+      expect(result.error).toBe("Delete failed");
+      // Should revert - item should be back
+      expect(usePrepStore.getState().prepItems.length).toBe(2);
+    });
+  });
+
+  describe("updatePrepItem", () => {
+    beforeEach(() => {
+      usePrepStore.setState({
+        prepItems: [
+          { id: "item-1", quantity: 5, description: "Test" },
+        ] as never,
+      });
+    });
+
+    it("updates item optimistically", async () => {
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      });
+
+      const promise = usePrepStore.getState().updatePrepItem("item-1", { quantity: 10 });
+
+      // Optimistic update
+      expect(usePrepStore.getState().prepItems[0].quantity).toBe(10);
+
+      await promise;
+    });
+
+    it("returns error when item not found", async () => {
+      const result = await usePrepStore.getState().updatePrepItem("nonexistent", { quantity: 10 });
+      expect(result.error).toBe("Item not found");
+    });
+
+    it("reverts on database error", async () => {
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: { message: "Update failed" } }),
+        })),
+      });
+
+      const result = await usePrepStore.getState().updatePrepItem("item-1", { quantity: 10 });
+
+      expect(result.error).toBe("Update failed");
+      // Should revert to original
+      expect(usePrepStore.getState().prepItems[0].quantity).toBe(5);
+    });
+
+    it("includes optimistic data for derived fields", async () => {
+      mockSupabase.from.mockReturnValue({
+        update: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      });
+
+      await usePrepStore.getState().updatePrepItem(
+        "item-1",
+        { unit_id: "new-unit" },
+        { unit_name: "kg" }
+      );
+
+      expect(usePrepStore.getState().prepItems[0].unit_name).toBe("kg");
+    });
+  });
+});

--- a/apps/web/src/test/unit/suggestionUtils.test.ts
+++ b/apps/web/src/test/unit/suggestionUtils.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  calculateRecencyScore,
+  calculateWeightedScore,
+  rankSuggestions,
+  formatQuantityDisplay,
+} from "@/lib/suggestionUtils";
+
+describe("suggestionUtils", () => {
+  describe("calculateRecencyScore", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-06-15T12:00:00"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns 0.2 for null lastUsed", () => {
+      expect(calculateRecencyScore(null)).toBe(0.2);
+    });
+
+    it("returns 1.0 for items used today", () => {
+      expect(calculateRecencyScore("2024-06-15")).toBe(1.0);
+    });
+
+    it("returns 0.8 for items used yesterday", () => {
+      expect(calculateRecencyScore("2024-06-14")).toBe(0.8);
+    });
+
+    it("returns 0.5 for items used within the week", () => {
+      expect(calculateRecencyScore("2024-06-10")).toBe(0.5);
+      expect(calculateRecencyScore("2024-06-09")).toBe(0.5);
+    });
+
+    it("returns 0.2 for items used more than a week ago", () => {
+      expect(calculateRecencyScore("2024-06-01")).toBe(0.2);
+      expect(calculateRecencyScore("2024-01-01")).toBe(0.2);
+    });
+  });
+
+  describe("calculateWeightedScore", () => {
+    it("calculates weighted score with default max use count", () => {
+      // (10/50) * 0.4 + 0.5 * 0.6 = 0.08 + 0.3 = 0.38
+      expect(calculateWeightedScore(10, 0.5)).toBeCloseTo(0.38);
+    });
+
+    it("calculates weighted score with custom max use count", () => {
+      // (20/100) * 0.4 + 0.8 * 0.6 = 0.08 + 0.48 = 0.56
+      expect(calculateWeightedScore(20, 0.8, 100)).toBeCloseTo(0.56);
+    });
+
+    it("caps use count at max value", () => {
+      // (50/50) * 0.4 + 1.0 * 0.6 = 0.4 + 0.6 = 1.0
+      expect(calculateWeightedScore(100, 1.0, 50)).toBeCloseTo(1.0);
+    });
+
+    it("handles null use count", () => {
+      // (0/50) * 0.4 + 0.5 * 0.6 = 0 + 0.3 = 0.3
+      expect(calculateWeightedScore(null, 0.5)).toBeCloseTo(0.3);
+    });
+
+    it("handles zero use count", () => {
+      // (0/50) * 0.4 + 1.0 * 0.6 = 0 + 0.6 = 0.6
+      expect(calculateWeightedScore(0, 1.0)).toBeCloseTo(0.6);
+    });
+  });
+
+  describe("rankSuggestions", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-06-15T12:00:00"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Minimal mock data - rankSuggestions only uses id, use_count, last_used, description
+    const mockSuggestions = [
+      {
+        id: "1",
+        description: "Carrots",
+        use_count: 10,
+        last_used: "2024-06-15",
+      },
+      {
+        id: "2",
+        description: "Onions",
+        use_count: 5,
+        last_used: "2024-06-10",
+      },
+      {
+        id: "3",
+        description: "Tomatoes",
+        use_count: 50,
+        last_used: "2024-01-01",
+      },
+    ] as Parameters<typeof rankSuggestions>[0];
+
+    it("returns top N suggestions sorted by weighted score", () => {
+      const result = rankSuggestions(mockSuggestions, new Set(), [], 2);
+      expect(result.length).toBe(2);
+      // First should be highest scored (Carrots - used today, decent count)
+      expect(result[0].id).toBe("1");
+    });
+
+    it("excludes dismissed suggestions", () => {
+      const dismissedIds = new Set(["1"]);
+      const result = rankSuggestions(mockSuggestions, dismissedIds, [], 3);
+      expect(result.find((s) => s.id === "1")).toBeUndefined();
+      expect(result.length).toBe(2);
+    });
+
+    it("excludes suggestions already in current items", () => {
+      const currentItems = [
+        { id: "item-1", description: "Carrots" },
+      ] as Array<{ id: string; description: string }>;
+      const result = rankSuggestions(mockSuggestions, new Set(), currentItems as never, 3);
+      expect(result.find((s) => s.description === "Carrots")).toBeUndefined();
+    });
+
+    it("returns all suggestions when topN is null", () => {
+      const result = rankSuggestions(mockSuggestions, new Set(), [], null);
+      expect(result.length).toBe(3);
+    });
+
+    it("includes recency and weighted scores in result", () => {
+      const result = rankSuggestions(mockSuggestions, new Set(), [], 1);
+      expect(result[0]).toHaveProperty("recencyScore");
+      expect(result[0]).toHaveProperty("weightedScore");
+      expect(result[0].dismissed).toBe(false);
+    });
+
+    it("handles empty suggestions array", () => {
+      const result = rankSuggestions([], new Set(), [], 3);
+      expect(result).toEqual([]);
+    });
+
+    it("is case-insensitive when filtering duplicates", () => {
+      const currentItems = [
+        { id: "item-1", description: "CARROTS" },
+      ] as Array<{ id: string; description: string }>;
+      const result = rankSuggestions(mockSuggestions, new Set(), currentItems as never, 3);
+      expect(result.find((s) => s.description?.toLowerCase() === "carrots")).toBeUndefined();
+    });
+  });
+
+  describe("formatQuantityDisplay", () => {
+    it("returns empty string when both quantity and unit are empty", () => {
+      expect(formatQuantityDisplay(null, null)).toBe("");
+      expect(formatQuantityDisplay(null, undefined)).toBe("");
+    });
+
+    it("returns formatted string with quantity and unit", () => {
+      expect(formatQuantityDisplay(5, "lbs")).toBe("5 lbs");
+      expect(formatQuantityDisplay(2.5, "kg")).toBe("2.5 kg");
+    });
+
+    it("returns just unit when quantity is null", () => {
+      expect(formatQuantityDisplay(null, "each")).toBe("each");
+    });
+
+    it("returns just quantity when unit is null", () => {
+      expect(formatQuantityDisplay(10, null)).toBe("10");
+      expect(formatQuantityDisplay(3, undefined)).toBe("3");
+    });
+
+    it("handles zero quantity", () => {
+      // 0 is falsy, should return empty string
+      expect(formatQuantityDisplay(0, null)).toBe("");
+      expect(formatQuantityDisplay(0, "lbs")).toBe("lbs");
+    });
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,13 +25,14 @@ export default defineConfig({
         "src/main.tsx",
         "src/vite-env.d.ts",
       ],
-      // Thresholds can be enabled once coverage improves
-      // thresholds: {
-      //   statements: 50,
-      //   branches: 40,
-      //   functions: 40,
-      //   lines: 50,
-      // },
+      // Coverage thresholds - CI will fail if coverage drops below these
+      // Baseline set 2024-12-31: ~28% overall
+      thresholds: {
+        statements: 25,
+        branches: 23,
+        functions: 24,
+        lines: 25,
+      },
     },
   },
 });


### PR DESCRIPTION
## What does this PR do?

Increases test coverage from ~21% to ~29% and enables coverage threshold enforcement in CI.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other: Test coverage

## Changes

### New unit tests
- `src/test/unit/dateUtils.test.ts` - 22 tests for date utilities
- `src/test/unit/suggestionUtils.test.ts` - 22 tests for suggestion ranking
- `src/test/unit/entitlements.test.ts` - 14 tests for plan limits and permissions
- `src/test/unit/stores/authStore.test.ts` - 14 tests for auth store
- `src/test/unit/stores/kitchenStore.test.ts` - 15 tests for kitchen store
- `src/test/unit/stores/prepStore.test.ts` - 20 tests for prep store

### Coverage enforcement
- Enabled thresholds in `vitest.config.ts`:
  - Statements: 25%
  - Branches: 23%
  - Functions: 24%
  - Lines: 25%
- **CI will now fail if coverage drops below these thresholds**

### Documentation
- Updated `.claude/commands/increase-coverage.md` with:
  - Correct command (`pnpm --filter web test:coverage`)
  - How to mock Supabase with `vi.hoisted()`
  - How to update thresholds after increasing coverage
  - Supabase database testing info

## Coverage report
```
Statements: 28.46%
Branches: 26.41%
Functions: 27.6%
Lines: 28.71%
```

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)