### PR TITLE
fix: use cursor-default on kitchen name in dashboard header

### DIFF
--- a/apps/web/src/pages/KitchenDashboard.tsx
+++ b/apps/web/src/pages/KitchenDashboard.tsx
@@ -122,7 +122,7 @@ export function KitchenDashboard() {
         <div className="flex items-center gap-2">
           <Logo size="sm" showText={false} />
           <span
-            className={`text-lg font-semibold ${
+            className={`text-lg font-semibold cursor-default ${
               isDark ? "text-white" : "text-stone-900"
             }`}
           >


### PR DESCRIPTION
## What does this PR do?
Fixes the kitchen name in the KitchenDashboard header to use `cursor-default` instead of the inherited pointer cursor, since it's not clickable.

## Type of change
- [x] Bug fix

## Checklist
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)