### PR TITLE
fix: use cursor-default on station name in StationView header

### DIFF
--- a/apps/web/src/pages/StationView.tsx
+++ b/apps/web/src/pages/StationView.tsx
@@ -191,7 +191,7 @@ export function StationView() {
         <div className="flex items-center gap-2">
           <Logo size="sm" showText={false} />
           <span
-            className={`text-lg font-semibold ${
+            className={`text-lg font-semibold cursor-default ${
               isDark ? "text-white" : "text-stone-900"
             }`}
           >


### PR DESCRIPTION
## What does this PR do?

Fixes the station name in the StationView header to use `cursor-default` instead of showing a pointer cursor on hover. The station name is not clickable, so the pointer cursor was misleading.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Documentation (changes to documentation only)
- [ ] Other (please describe):

## Checklist

- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm build` successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have tested my changes manually in the browser

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)