### PR TITLE
fix: settings polish - paywall, names, responsive design

### DIFF
--- a/apps/web/src/components/settings/MembersSettingsTab.tsx
+++ b/apps/web/src/components/settings/MembersSettingsTab.tsx
@@ -10,6 +10,7 @@ interface MembersSettingsTabProps {
   kitchenId: string;
   userId?: string;
   isOwner: boolean;
+  canInvite: boolean;
   onInviteClick: () => void;
 }
 
@@ -17,6 +18,7 @@ export function MembersSettingsTab({
   kitchenId,
   userId,
   isOwner,
+  canInvite,
   onInviteClick,
 }: MembersSettingsTabProps) {
   const { isDark } = useDarkModeContext();
@@ -26,9 +28,6 @@ export function MembersSettingsTab({
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
-
-  const currentUserMember = members.find((m) => m.user_id === userId);
-  const canInvite = isOwner || currentUserMember?.can_invite;
 
   const handleRemove = async (memberId: string) => {
     if (!confirm("Remove this member from the kitchen?")) return;
@@ -95,102 +94,131 @@ export function MembersSettingsTab({
         description="Manage who has access to this kitchen"
       >
         <div className="space-y-3">
-          {members.map((member) => (
-            <div
-              key={member.id}
-              className={`flex items-center justify-between p-4 rounded-xl ${
-                isDark ? "bg-slate-800" : "bg-stone-50"
-              }`}
-            >
-              <div>
-                <p
-                  className={`font-medium ${
-                    isDark ? "text-white" : "text-gray-900"
-                  }`}
-                >
-                  {member.user_id ? "Registered User" : "Anonymous User"}
-                </p>
-                <p
-                  className={`text-sm capitalize ${
-                    isDark ? "text-gray-400" : "text-gray-600"
-                  }`}
-                >
-                  {member.role}
-                </p>
-              </div>
+          {members.map((member) => {
+            // Get display name with fallbacks
+            const displayName =
+              member.display_name ||
+              (member.email ? member.email.split("@")[0] : null) ||
+              (member.is_anonymous ? "Anonymous User" : "User");
+            const isCurrentUser = member.user_id === userId;
 
-              {member.role === "owner" ? (
-                <span
-                  className={`px-3 py-1 rounded-full text-sm font-semibold ${
-                    isDark
-                      ? "bg-orange-500/20 text-orange-400"
-                      : "bg-orange-100 text-orange-600"
-                  }`}
-                >
-                  Owner
-                </span>
-              ) : isOwner ? (
-                <div className="flex items-center gap-4">
-                  <select
-                    value={member.role}
-                    onChange={(e) =>
-                      handleRoleChange(
-                        member.id,
-                        e.target
-                          .value as Database["public"]["Enums"]["member_role"]
-                      )
-                    }
-                    disabled={updatingId === member.id}
-                    className={`px-3 py-2 border rounded-lg text-sm disabled:opacity-50 cursor-pointer ${
-                      isDark
-                        ? "bg-slate-700 border-slate-600 text-white"
-                        : "bg-white border-stone-300 text-gray-900"
-                    }`}
-                  >
-                    <option value="member">Member</option>
-                    <option value="admin">Admin</option>
-                  </select>
-
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={member.can_invite || false}
-                      onChange={(e) =>
-                        handleInvitePermissionChange(
-                          member.id,
-                          e.target.checked
-                        )
-                      }
-                      disabled={updatingId === member.id}
-                      className="w-4 h-4 accent-orange-500"
-                    />
-                    <span
-                      className={`text-sm ${
+            return (
+              <div
+                key={member.id}
+                className={`p-4 rounded-xl ${
+                  isDark ? "bg-slate-800" : "bg-stone-50"
+                }`}
+              >
+                {/* Mobile: Stack layout, Desktop: Row layout */}
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                  {/* User info */}
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={`font-medium truncate ${
+                        isDark ? "text-white" : "text-gray-900"
+                      }`}
+                    >
+                      {displayName}
+                      {isCurrentUser && (
+                        <span
+                          className={`ml-2 text-sm font-normal ${
+                            isDark ? "text-gray-400" : "text-gray-500"
+                          }`}
+                        >
+                          (You)
+                        </span>
+                      )}
+                    </p>
+                    <p
+                      className={`text-sm truncate ${
                         isDark ? "text-gray-400" : "text-gray-600"
                       }`}
                     >
-                      Can invite
-                    </span>
-                  </label>
+                      <span className="capitalize">{member.role}</span>
+                      {member.email && !member.is_anonymous && (
+                        <span className="ml-2">• {member.email}</span>
+                      )}
+                      {member.is_anonymous && (
+                        <span className="ml-2">• Guest</span>
+                      )}
+                    </p>
+                  </div>
 
-                  <button
-                    onClick={() => handleRemove(member.id)}
-                    disabled={updatingId === member.id}
-                    className="text-red-500 hover:text-red-600 font-semibold text-sm disabled:opacity-50 cursor-pointer"
-                  >
-                    Remove
-                  </button>
+                  {/* Actions */}
+                  {member.role === "owner" ? (
+                    <span
+                      className={`self-start md:self-center flex-shrink-0 px-3 py-1 rounded-full text-sm font-semibold ${
+                        isDark
+                          ? "bg-orange-500/20 text-orange-400"
+                          : "bg-orange-100 text-orange-600"
+                      }`}
+                    >
+                      Owner
+                    </span>
+                  ) : isOwner ? (
+                    <div className="flex flex-wrap items-center gap-3 md:gap-4">
+                      <select
+                        value={member.role}
+                        onChange={(e) =>
+                          handleRoleChange(
+                            member.id,
+                            e.target
+                              .value as Database["public"]["Enums"]["member_role"]
+                          )
+                        }
+                        disabled={updatingId === member.id}
+                        className={`px-3 py-2 border rounded-lg text-sm disabled:opacity-50 cursor-pointer ${
+                          isDark
+                            ? "bg-slate-700 border-slate-600 text-white"
+                            : "bg-white border-stone-300 text-gray-900"
+                        }`}
+                      >
+                        <option value="member">Member</option>
+                        <option value="admin">Admin</option>
+                      </select>
+
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={member.can_invite || false}
+                          onChange={(e) =>
+                            handleInvitePermissionChange(
+                              member.id,
+                              e.target.checked
+                            )
+                          }
+                          disabled={updatingId === member.id}
+                          className="w-4 h-4 accent-orange-500"
+                        />
+                        <span
+                          className={`text-sm whitespace-nowrap ${
+                            isDark ? "text-gray-400" : "text-gray-600"
+                          }`}
+                        >
+                          Can invite
+                        </span>
+                      </label>
+
+                      <button
+                        onClick={() => handleRemove(member.id)}
+                        disabled={updatingId === member.id}
+                        className="text-red-500 hover:text-red-600 font-semibold text-sm disabled:opacity-50 cursor-pointer whitespace-nowrap"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
-              ) : null}
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       </SettingsSection>
 
-      {canInvite && (
+      {(isOwner || canInvite) && (
         <SettingsSection title="Invite Members">
           <Button variant="primary" onClick={onInviteClick}>
-            Generate Invite Link
+            {canInvite ? "Generate Invite Link" : "Upgrade to Invite"}
           </Button>
         </SettingsSection>
       )}

--- a/apps/web/src/components/settings/PersonalSettingsTab.tsx
+++ b/apps/web/src/components/settings/PersonalSettingsTab.tsx
@@ -11,21 +11,30 @@ interface PersonalSettingsTabProps {
   user: User;
 }
 
+// Get user's display name with fallbacks (same pattern as UserAvatarMenu)
+function getUserDisplayName(user: User): string {
+  const name = user.user_metadata?.name;
+  if (name && typeof name === "string") return name;
+
+  const displayName = user.user_metadata?.display_name;
+  if (displayName && typeof displayName === "string") return displayName;
+
+  return "";
+}
+
 export function PersonalSettingsTab({ user }: PersonalSettingsTabProps) {
   const { isDark, toggle } = useDarkModeContext();
-  const [displayName, setDisplayName] = useState(
-    user.user_metadata?.name || ""
-  );
+  const originalName = getUserDisplayName(user);
+  const [displayName, setDisplayName] = useState(originalName);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
-  const originalName = user.user_metadata?.name || "";
   const hasChanges = displayName !== originalName;
 
   useEffect(() => {
-    setDisplayName(user.user_metadata?.name || "");
-  }, [user.user_metadata?.name]);
+    setDisplayName(getUserDisplayName(user));
+  }, [user]);
 
   const handleSave = async () => {
     if (!displayName.trim()) {

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -84,26 +84,93 @@ export function Settings() {
     (m) => m.kitchen_id === activeSection
   );
 
+  // Filter to only show kitchens where user is owner or admin
+  const manageableKitchens = kitchens.filter((kitchen) => {
+    const membership = memberships.find((m) => m.kitchen_id === kitchen.id);
+    return membership?.role === "owner" || membership?.role === "admin";
+  });
+
   const handleKitchenDeleted = () => {
     setActiveSection("personal");
   };
 
+  // Mobile nav pill button styles
+  const getMobilePillClass = (isActive: boolean) => {
+    const base =
+      "flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors whitespace-nowrap";
+    if (isActive) {
+      return `${base} ${
+        isDark
+          ? "bg-orange-500/20 text-orange-400"
+          : "bg-orange-100 text-orange-600"
+      }`;
+    }
+    return `${base} ${
+      isDark
+        ? "bg-slate-800 text-gray-400 hover:text-white"
+        : "bg-stone-100 text-gray-600 hover:text-gray-900"
+    }`;
+  };
+
   return (
     <div data-testid="page-settings">
-      <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="max-w-6xl mx-auto px-4 py-6 md:py-8">
+        {/* Mobile Navigation */}
+        <div className="md:hidden mb-6">
+          <div className="overflow-x-auto -mx-4 px-4">
+            <div className="flex gap-2 pb-2">
+              {/* Account section pills */}
+              <button
+                onClick={() => setActiveSection("personal")}
+                className={getMobilePillClass(activeSection === "personal")}
+              >
+                Personal
+              </button>
+              <button
+                onClick={() => setActiveSection("billing")}
+                className={getMobilePillClass(activeSection === "billing")}
+              >
+                Billing
+              </button>
+
+              {/* Divider */}
+              {manageableKitchens.length > 0 && (
+                <div
+                  className={`flex-shrink-0 w-px mx-1 ${
+                    isDark ? "bg-slate-700" : "bg-stone-300"
+                  }`}
+                />
+              )}
+
+              {/* Kitchen pills */}
+              {manageableKitchens.map((kitchen) => (
+                <button
+                  key={kitchen.id}
+                  onClick={() => setActiveSection(kitchen.id)}
+                  className={getMobilePillClass(activeSection === kitchen.id)}
+                >
+                  {kitchen.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
         <div className="flex gap-8">
-          {/* Sidebar */}
-          <SettingsSidebar
-            activeSection={activeSection}
-            onSectionChange={setActiveSection}
-            kitchens={kitchens}
-            memberships={memberships}
-          />
+          {/* Sidebar - Hidden on mobile */}
+          <div className="hidden md:block">
+            <SettingsSidebar
+              activeSection={activeSection}
+              onSectionChange={setActiveSection}
+              kitchens={kitchens}
+              memberships={memberships}
+            />
+          </div>
 
           {/* Content */}
           <div
             data-testid="settings-content"
-            className="flex-1 max-w-3xl"
+            className="flex-1 min-w-0 md:max-w-3xl"
           >
             {loading ? (
               <div className="flex items-center justify-center h-64">

--- a/packages/types/src/database.ts
+++ b/packages/types/src/database.ts
@@ -529,6 +529,20 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      get_kitchen_members_with_names: {
+        Args: { p_kitchen_id: string }
+        Returns: {
+          can_invite: boolean
+          display_name: string
+          email: string
+          id: string
+          is_anonymous: boolean
+          joined_at: string
+          kitchen_id: string
+          role: Database["public"]["Enums"]["member_role"]
+          user_id: string
+        }[]
+      }
       is_anonymous_user: { Args: never; Returns: boolean }
       is_kitchen_admin_or_owner: {
         Args: { p_kitchen_id: string }

--- a/supabase/migrations/20260103184726_get_kitchen_members_with_names.sql
+++ b/supabase/migrations/20260103184726_get_kitchen_members_with_names.sql
@@ -1,0 +1,52 @@
+-- Create a function to get kitchen members with their display names
+-- This safely exposes limited user metadata for kitchen members
+
+create or replace function get_kitchen_members_with_names(p_kitchen_id uuid)
+returns table (
+  id uuid,
+  kitchen_id uuid,
+  user_id uuid,
+  role public.member_role,
+  can_invite boolean,
+  joined_at timestamptz,
+  display_name text,
+  email text,
+  is_anonymous boolean
+)
+language sql
+security definer
+stable
+as $$
+  select
+    km.id,
+    km.kitchen_id,
+    km.user_id,
+    km.role,
+    km.can_invite,
+    km.joined_at,
+    coalesce(
+      au.raw_user_meta_data->>'name',
+      au.raw_user_meta_data->>'display_name'
+    ) as display_name,
+    au.email,
+    coalesce(au.is_anonymous, false) as is_anonymous
+  from kitchen_members km
+  join auth.users au on au.id = km.user_id
+  where km.kitchen_id = p_kitchen_id
+  -- Only allow access if the caller is a member of this kitchen
+  and exists (
+    select 1 from kitchen_members
+    where kitchen_id = p_kitchen_id
+    and user_id = auth.uid()
+  )
+  order by
+    case km.role
+      when 'owner' then 1
+      when 'admin' then 2
+      else 3
+    end,
+    km.joined_at;
+$$;
+
+-- Grant execute to authenticated users
+grant execute on function get_kitchen_members_with_names(uuid) to authenticated;


### PR DESCRIPTION
## What does this PR do?

Polishes the settings dashboard with three key fixes:

1. **Paywall for invites (#42)**: Free users now see an upgrade modal when trying to invite members instead of generating invite links
2. **Fix user names display (#46)**: Members list now shows actual user names from user metadata via a new RPC function (instead of "Registered User")
3. **Responsive mobile design (#47)**: Settings page now has a horizontal scrollable pill navigation on mobile with properly responsive member rows

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (all 434 tests)

## Changes

### Paywall (#42)
- `KitchenSettingsPanel.tsx`: Added `usePlanLimits` hook to check invite permissions
- `MembersSettingsTab.tsx`: Now receives `canInvite` as prop instead of computing internally
- `UpgradeModal`: Shows different content for invites vs stations upgrade

### User Names (#46)
- Added RPC migration `get_kitchen_members_with_names.sql` to safely expose user metadata
- `useRealtimeMembers.ts`: Updated to use RPC and return `MemberWithUserInfo` type with `display_name`, `email`, `is_anonymous`
- `MembersSettingsTab.tsx`: Shows actual names with fallbacks, "(You)" indicator for current user
- `PersonalSettingsTab.tsx`: Uses same name fallback pattern as `UserAvatarMenu`

### Responsive Design (#47)
- `Settings.tsx`: Mobile navigation with horizontal scrollable pills, sidebar hidden on mobile
- `MembersSettingsTab.tsx`: Responsive member rows (stack on mobile, row on desktop)
- `KitchenSettingsPanel.tsx`: Responsive heading with truncate

## Screenshots

Mobile navigation uses horizontal scrollable pills with divider between account and kitchen sections.

Fixes #42, #46, #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)