### PR TITLE
fix: show generic error message on login failure

### DIFF
--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -61,7 +61,8 @@ export const useAuthStore = create<AuthState>()(
         } else {
           set({ loading: false });
         }
-        return { error: error?.message };
+        // Return generic error message for security - don't reveal if email exists
+        return { error: error ? "Invalid email or password" : undefined };
       },
 
       signUp: async (email, password, name) => {

--- a/apps/web/src/test/unit/stores/authStore.test.ts
+++ b/apps/web/src/test/unit/stores/authStore.test.ts
@@ -131,7 +131,7 @@ describe("authStore", () => {
       expect(state.loading).toBe(false);
     });
 
-    it("returns error message on failure", async () => {
+    it("returns generic error message on failure for security", async () => {
       mockSupabase.auth.signInWithPassword.mockResolvedValue({
         data: { session: null, user: null },
         error: { message: "Invalid credentials" },
@@ -139,7 +139,8 @@ describe("authStore", () => {
 
       const result = await useAuthStore.getState().signIn("test@example.com", "wrong");
 
-      expect(result.error).toBe("Invalid credentials");
+      // Generic message hides whether email exists (security best practice)
+      expect(result.error).toBe("Invalid email or password");
       expect(useAuthStore.getState().loading).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

- Return generic "Invalid email or password" error for all login failures
- Prevents revealing whether an email exists in the system (security best practice)
- Error is displayed inline via the existing Alert component

## What does this PR do?

Fixes the lack of error feedback when users enter wrong credentials. The authStore now returns a user-friendly, security-conscious error message that:
- Shows inline error message on failed login attempt ✅
- Clears on next attempt (existing behavior) ✅  
- Doesn't reveal whether email exists (generic message) ✅

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (434 tests)
- [ ] Changes tested manually

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)