### PR TITLE
fix: correct Pro pricing and kitchen limits in billing UI

### DIFF
--- a/apps/web/src/components/kitchen/StepUpgrade.tsx
+++ b/apps/web/src/components/kitchen/StepUpgrade.tsx
@@ -33,7 +33,7 @@ export function StepUpgrade({
       description:
         "Your free plan includes 1 kitchen. Upgrade to Pro to manage all your locations from one account.",
       benefits: [
-        "Unlimited kitchens",
+        "Up to 5 kitchens",
         "Unlimited stations per kitchen",
         "Unlimited team members",
       ],

--- a/apps/web/src/components/settings/BillingSettingsTab.tsx
+++ b/apps/web/src/components/settings/BillingSettingsTab.tsx
@@ -115,7 +115,7 @@ export function BillingSettingsTab({ userId }: BillingSettingsTabProps) {
                 isDark ? "text-orange-300" : "text-orange-700"
               }`}
             >
-              <li>✓ Unlimited kitchens</li>
+              <li>✓ Up to 5 kitchens</li>
               <li>✓ Unlimited stations per kitchen</li>
               <li>✓ Invite team members</li>
               <li>✓ Real-time collaboration</li>
@@ -127,7 +127,7 @@ export function BillingSettingsTab({ userId }: BillingSettingsTabProps) {
             disabled={checkoutLoading}
             fullWidth
           >
-            {checkoutLoading ? "Redirecting..." : "Upgrade to Pro - $9/month"}
+            {checkoutLoading ? "Redirecting..." : "Upgrade to Pro - $29/month"}
           </Button>
         </SettingsSection>
       )}


### PR DESCRIPTION
## Summary

- Fix displayed price from $9/month to $29/month in BillingSettingsTab
- Fix "Unlimited kitchens" to "Up to 5 kitchens" in BillingSettingsTab and StepUpgrade
- Aligns UI with actual plan limits defined in `entitlements.ts`

## What does this PR do?

The billing settings were showing incorrect pricing ($9 instead of $29) and claiming "unlimited kitchens" when the Pro plan actually limits users to 5 kitchens. This PR corrects both issues to match the actual plan configuration.

**Files changed:**
- `BillingSettingsTab.tsx` - Fixed price and kitchen limit text
- `StepUpgrade.tsx` - Fixed kitchen limit text in upgrade prompt

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (434 tests)
- [ ] Changes tested manually

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)