### PR TITLE
fix: replace console statements with Sentry error capture

### DIFF
--- a/apps/web/src/components/modals/CopyRecentItemsModal.tsx
+++ b/apps/web/src/components/modals/CopyRecentItemsModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import { usePrepEntryStore, usePrepStore } from "@/stores";
 import { Pill } from "@/components/ui";
 import { XIcon, CheckIcon } from "@/components/icons";
@@ -111,7 +111,7 @@ export function CopyRecentItemsModal({
         ]);
 
         if (recentResponse.error) {
-          console.error("Error fetching recent items:", recentResponse.error);
+          captureError(recentResponse.error, { context: "CopyRecentItemsModal.fetchRecentItems" });
           return;
         }
 
@@ -288,7 +288,7 @@ export function CopyRecentItemsModal({
       const { error } = await supabase.from("prep_items").insert(itemsToAdd);
 
       if (error) {
-        console.error("Error adding items:", error);
+        captureError(error, { context: "CopyRecentItemsModal.addItems" });
       }
 
       // Reload prep items to show the new items

--- a/apps/web/src/components/modals/InviteLinkModal.tsx
+++ b/apps/web/src/components/modals/InviteLinkModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import QRCode from "qrcode";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import { useDarkModeContext } from "@/context";
 import { Modal } from "../ui/Modal";
 import { Button } from "../ui/Button";
@@ -86,7 +86,7 @@ export function InviteLinkModal({
           },
         })
           .then(setQrCodeUrl)
-          .catch(console.error);
+          .catch((err) => captureError(err, { context: "InviteLinkModal.qrCode" }));
       });
     }
   }, [activeLink, isDark]);

--- a/apps/web/src/components/modals/UnitsModal.tsx
+++ b/apps/web/src/components/modals/UnitsModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from "@headlessui/react";
 import { useKitchenStore, usePrepEntryStore } from "@/stores";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import type { KitchenUnit } from "@kniferoll/types";
 import { Pill } from "@/components/ui";
 import { ChevronDownIcon, XIcon } from "@/components/icons";
@@ -136,7 +136,7 @@ export function UnitsModal({
         onUnitSelected(data);
       }
     } catch (err) {
-      console.error("Error creating unit:", err);
+      captureError(err as Error, { context: "UnitsModal.createUnit" });
     } finally {
       setIsCreating(false);
     }

--- a/apps/web/src/components/prep/PrepItemEntryForm.tsx
+++ b/apps/web/src/components/prep/PrepItemEntryForm.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import type { KitchenUnit, RecencyScoredSuggestion } from "@kniferoll/types";
+import { captureError } from "@/lib";
 import { UnitsModal } from "@/components/modals/UnitsModal";
 import { Pill } from "@/components/ui";
 import { usePrepEntryStore } from "@/stores";
@@ -224,7 +225,7 @@ export function PrepItemEntryForm({
         }, 0);
       }
     } catch (error) {
-      console.error("Error adding item:", error);
+      captureError(error as Error, { context: "PrepItemEntryForm.addItem" });
     } finally {
       isSubmitting.current = false;
     }

--- a/apps/web/src/components/settings/KitchenSettingsPanel.tsx
+++ b/apps/web/src/components/settings/KitchenSettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { captureError } from "@/lib";
 import { useDarkModeContext } from "@/context";
 import { useStripeCheckout, usePlanLimits } from "@/hooks";
 import {
@@ -149,7 +150,7 @@ export function KitchenSettingsPanel({
           try {
             await handleCheckout();
           } catch (error) {
-            console.error("Checkout failed:", error);
+            captureError(error as Error, { context: "KitchenSettingsPanel.checkout" });
           }
         }}
       />

--- a/apps/web/src/hooks/useRealtimePrepItems.ts
+++ b/apps/web/src/hooks/useRealtimePrepItems.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import { usePrepStore, type PrepItemWithDescription } from "@/stores";
 import type { DbPrepItem } from "@kniferoll/types";
 
@@ -129,10 +129,11 @@ export function useRealtimePrepItems(
         }
       )
       .subscribe((status) => {
-        if (status === "SUBSCRIBED") {
-          console.log(`Realtime subscribed: prep_items for station ${stationId}`);
-        } else if (status === "CHANNEL_ERROR") {
-          console.error("Realtime subscription error for prep_items");
+        if (status === "CHANNEL_ERROR") {
+          captureError(new Error("Realtime subscription error for prep_items"), {
+            context: "useRealtimePrepItems",
+            stationId,
+          });
         }
       });
 

--- a/apps/web/src/hooks/useStripeCheckout.ts
+++ b/apps/web/src/hooks/useStripeCheckout.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { useAuthStore } from "@/stores";
-import { redirectToCheckout } from "@/lib";
+import { redirectToCheckout, captureError } from "@/lib";
 
 /**
  * Hook for handling Stripe checkout redirects
@@ -27,7 +27,7 @@ export function useStripeCheckout() {
       // Don't set loading false on success - we're redirecting
     } catch (error) {
       setLoading(false);
-      console.error("Checkout error:", error);
+      captureError(error as Error, { context: "useStripeCheckout" });
       throw error;
     }
   }, [user]);

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { supabase } from "./supabase";
+import { captureError } from "./sentry";
 import type { UserProfile } from "@kniferoll/types";
 import type { User } from "@supabase/supabase-js";
 
@@ -12,7 +13,7 @@ export async function getCurrentSession() {
   } = await supabase.auth.getSession();
 
   if (error) {
-    console.error("Error getting session:", error);
+    captureError(error, { context: "getCurrentSession" });
     return null;
   }
 
@@ -29,7 +30,7 @@ export async function getCurrentUser() {
   } = await supabase.auth.getUser();
 
   if (error) {
-    console.error("Error getting current user:", error);
+    captureError(error, { context: "getCurrentUser" });
     return null;
   }
 
@@ -52,7 +53,7 @@ export async function signInAnonymously() {
   const { data, error } = await supabase.auth.signInAnonymously();
 
   if (error) {
-    console.error("Error signing in anonymously:", error);
+    captureError(error, { context: "signInAnonymously" });
     return { user: null, error };
   }
 
@@ -79,7 +80,7 @@ export async function signUp(
   });
 
   if (error) {
-    console.error("Error signing up:", error);
+    captureError(error, { context: "signUp" });
     return { user: null, error };
   }
 
@@ -96,7 +97,7 @@ export async function signIn(email: string, password: string) {
   });
 
   if (error) {
-    console.error("Error signing in:", error);
+    captureError(error, { context: "signIn" });
     return { user: null, error };
   }
 
@@ -110,7 +111,7 @@ export async function signOut() {
   const { error } = await supabase.auth.signOut();
 
   if (error) {
-    console.error("Error signing out:", error);
+    captureError(error, { context: "signOut" });
     return { error };
   }
 
@@ -131,7 +132,7 @@ export async function getCurrentUserProfile(): Promise<UserProfile | null> {
     .single();
 
   if (error) {
-    console.error("Error fetching user profile:", error);
+    captureError(error, { context: "getCurrentUserProfile" });
     return null;
   }
 
@@ -153,7 +154,7 @@ export async function updateUserProfile(
     .single();
 
   if (error) {
-    console.error("Error updating user profile:", error);
+    captureError(error, { context: "updateUserProfile", userId });
     return { error };
   }
 
@@ -169,7 +170,7 @@ export async function updateUserDisplayName(displayName: string) {
   });
 
   if (error) {
-    console.error("Error updating display name:", error);
+    captureError(error, { context: "updateUserDisplayName" });
     return { error };
   }
 

--- a/apps/web/src/lib/entitlements.ts
+++ b/apps/web/src/lib/entitlements.ts
@@ -1,4 +1,5 @@
 import { supabase } from "./supabase";
+import { captureError } from "./sentry";
 import type { Database } from "@kniferoll/types";
 
 type UserPlan = Database["public"]["Enums"]["user_plan"];
@@ -40,7 +41,7 @@ export async function getOwnedKitchenCount(userId: string): Promise<number> {
     .eq("owner_id", userId);
 
   if (error) {
-    console.error("Error fetching kitchen count:", error);
+    captureError(error, { context: "getOwnedKitchenCount", userId });
     return 0;
   }
 
@@ -70,7 +71,7 @@ export async function getStationCount(kitchenId: string): Promise<number> {
     .eq("kitchen_id", kitchenId);
 
   if (error) {
-    console.error("Error fetching station count:", error);
+    captureError(error, { context: "getStationCount", kitchenId });
     return 0;
   }
 
@@ -92,7 +93,9 @@ export async function canCreateStation(
     .single();
 
   if (kitchenError || !kitchen) {
-    console.error("Error fetching kitchen:", kitchenError);
+    if (kitchenError) {
+      captureError(kitchenError, { context: "canCreateStation", kitchenId });
+    }
     return false;
   }
 
@@ -123,7 +126,7 @@ export async function getMembership(userId: string, kitchenId: string) {
     .single();
 
   if (error) {
-    console.error("Error fetching membership:", error);
+    captureError(error, { context: "getMembership", userId, kitchenId });
     return null;
   }
 

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -4,10 +4,12 @@
  */
 
 import { supabase } from "./supabase";
+import { captureError } from "./sentry";
 
 const STRIPE_PUBLISHABLE_KEY = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY;
 
-if (!STRIPE_PUBLISHABLE_KEY) {
+if (!STRIPE_PUBLISHABLE_KEY && import.meta.env.DEV) {
+  // Only warn in development - production builds should have this set
   console.warn("VITE_STRIPE_PUBLISHABLE_KEY is not set");
 }
 
@@ -47,7 +49,7 @@ export async function redirectToCheckout(options: {
       throw new Error("No checkout URL returned");
     }
   } catch (error) {
-    console.error("Stripe checkout error:", error);
+    captureError(error as Error, { context: "redirectToCheckout" });
     throw error;
   }
 }
@@ -78,7 +80,7 @@ export async function getCustomerPortalUrl(options: {
     const { portalUrl } = data;
     return portalUrl;
   } catch (error) {
-    console.error("Stripe portal error:", error);
+    captureError(error as Error, { context: "getCustomerPortalUrl" });
     throw error;
   }
 }
@@ -94,7 +96,7 @@ export async function redirectToCustomerPortal(options: {
     const portalUrl = await getCustomerPortalUrl(options);
     window.location.href = portalUrl;
   } catch (error) {
-    console.error("Failed to redirect to portal:", error);
+    captureError(error as Error, { context: "redirectToCustomerPortal" });
     throw error;
   }
 }

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/components";
 import type { Database } from "@kniferoll/types";
 import { preloadKitchenDashboard } from "@/lib/preload";
-import { safeSetItem } from "@/lib";
+import { safeSetItem, captureError } from "@/lib";
 type Kitchen = Database["public"]["Tables"]["kitchens"]["Row"];
 
 /**
@@ -223,7 +223,7 @@ export function Dashboard() {
           try {
             await handleCheckout();
           } catch (error) {
-            console.error("Checkout failed:", error);
+            captureError(error as Error, { context: "Dashboard.checkout" });
           }
         }}
       />

--- a/apps/web/src/pages/KitchenDashboard.tsx
+++ b/apps/web/src/pages/KitchenDashboard.tsx
@@ -10,7 +10,7 @@ import {
   useStripeCheckout,
 } from "@/hooks";
 import { useDarkModeContext } from "@/context";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import { jsDateToDatabaseDayOfWeek, toLocalDate, isClosedDay, findNextOpenDay } from "@/lib";
 import {
   AddCard,
@@ -275,7 +275,7 @@ export function KitchenDashboard() {
           .eq("shift_id", selectedShiftId);
 
         if (error) {
-          console.error("Error fetching items:", error);
+          captureError(error, { context: "KitchenDashboard.fetchItems" });
           return;
         }
 
@@ -308,7 +308,7 @@ export function KitchenDashboard() {
         setProgress(progressData);
         setHasLoadedOnce(true);
       } catch (err) {
-        console.error("Failed to fetch progress:", err);
+        captureError(err as Error, { context: "KitchenDashboard.fetchProgress" });
       } finally {
         setIsProgressLoading(false);
       }
@@ -539,7 +539,7 @@ export function KitchenDashboard() {
           try {
             await handleCheckout();
           } catch (error) {
-            console.error("Checkout failed:", error);
+            captureError(error as Error, { context: "KitchenDashboard.checkout" });
           }
         }}
       />
@@ -560,7 +560,7 @@ export function KitchenDashboard() {
           try {
             await handleCheckout();
           } catch (error) {
-            console.error("Checkout failed:", error);
+            captureError(error as Error, { context: "KitchenDashboard.checkout" });
           }
         }}
       />

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useDarkModeContext } from "@/context";
 import { useAuthStore } from "@/stores";
 import { useKitchens, useHeaderConfig } from "@/hooks";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import { BackButton } from "@/components";
 import {
   SettingsSidebar,
@@ -45,7 +45,7 @@ export function Settings() {
         if (error) throw error;
         setMemberships(data || []);
       } catch (err) {
-        console.error("Failed to fetch memberships:", err);
+        captureError(err as Error, { context: "Settings.fetchMemberships" });
       } finally {
         setMembershipsLoading(false);
       }

--- a/apps/web/src/pages/StationView.tsx
+++ b/apps/web/src/pages/StationView.tsx
@@ -8,7 +8,7 @@ import {
   usePrepStore,
 } from "@/stores";
 import { useRealtimePrepItems, useHeaderConfig, usePlanLimits, useStripeCheckout, useVisualViewport } from "@/hooks";
-import { supabase, getDeviceToken, safeGetItem, safeSetItem } from "@/lib";
+import { supabase, getDeviceToken, safeGetItem, safeSetItem, captureError } from "@/lib";
 import { jsDateToDatabaseDayOfWeek, toLocalDate, isClosedDay, findNextOpenDay } from "@/lib";
 
 import {
@@ -803,7 +803,7 @@ export function StationView() {
           try {
             await handleCheckout();
           } catch (error) {
-            console.error("Checkout failed:", error);
+            captureError(error as Error, { context: "StationView.checkout" });
           }
         }}
       />

--- a/apps/web/src/stores/prepEntryStore.ts
+++ b/apps/web/src/stores/prepEntryStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { supabase } from "@/lib";
+import { supabase, captureError } from "@/lib";
 import type {
   DbKitchenUnit,
   DbPrepItem,
@@ -390,7 +390,7 @@ export const usePrepEntryStore = create<PrepEntryState>((set, get) => ({
           get().loadSuggestionsAndUnits(kitchenId, stationId, shiftDate, shiftId);
         } catch (err) {
           // Silent fail for background suggestion update - not critical
-          console.warn("Failed to update suggestions:", err);
+          captureError(err as Error, { context: "updateSuggestions" });
         }
       });
 

--- a/apps/web/src/test/unit/stores/kitchenStore.test.ts
+++ b/apps/web/src/test/unit/stores/kitchenStore.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib", () => ({
   supabase: mockSupabase,
   signInAnonymously: vi.fn(),
   getTodayLocalDate: vi.fn(() => "2024-06-15"),
+  captureError: vi.fn(),
 }));
 
 // Import after mocking

--- a/apps/web/src/test/unit/stores/prepEntryStore.test.ts
+++ b/apps/web/src/test/unit/stores/prepEntryStore.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/supabase", () => ({
 vi.mock("@/lib", () => ({
   supabase: mockSupabase,
   rankSuggestions: vi.fn((suggestions: unknown[]) => suggestions),
+  captureError: vi.fn(),
 }));
 
 // Import after mocking

--- a/apps/web/src/test/utils/providers.tsx
+++ b/apps/web/src/test/utils/providers.tsx
@@ -308,6 +308,11 @@ vi.mock("@/lib", () => ({
   // suggestionUtils
   filterSuggestions: vi.fn(() => []),
   rankSuggestions: vi.fn(() => []),
+
+  // sentry
+  captureError: vi.fn(),
+  initSentry: vi.fn(),
+  setSentryUser: vi.fn(),
 }));
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replace `console.error` calls with `captureError` from `@/lib/sentry` for proper error tracking
- Gate dev-only warning (missing Stripe key) behind `import.meta.env.DEV`
- Remove debug `console.log` statements from realtime subscription handlers
- Add `captureError` mock to test providers and store tests

## Files Changed (19 files)

### Library Files
- `lib/auth.ts` - All auth error handling now uses Sentry
- `lib/stripe.ts` - Checkout and portal errors captured; dev warning gated
- `lib/entitlements.ts` - Plan/kitchen/station count errors captured

### Stores
- `stores/kitchenStore.ts` - Kitchen creation errors captured
- `stores/prepEntryStore.ts` - Suggestion update errors captured

### Hooks
- `hooks/useRealtimePrepItems.ts` - Removed debug log; subscription errors captured
- `hooks/useStripeCheckout.ts` - Checkout errors captured

### Components
- `components/modals/InviteLinkModal.tsx` - QR code generation errors captured
- `components/modals/UnitsModal.tsx` - Unit creation errors captured
- `components/modals/CopyRecentItemsModal.tsx` - Item fetch/add errors captured
- `components/prep/PrepItemEntryForm.tsx` - Item add errors captured
- `components/settings/KitchenSettingsPanel.tsx` - Checkout errors captured

### Pages
- `pages/Dashboard.tsx` - Checkout errors captured
- `pages/KitchenDashboard.tsx` - Progress fetch and checkout errors captured
- `pages/Settings.tsx` - Membership fetch errors captured
- `pages/StationView.tsx` - Checkout errors captured

### Tests
- `test/utils/providers.tsx` - Added captureError mock
- `test/unit/stores/kitchenStore.test.ts` - Added captureError mock
- `test/unit/stores/prepEntryStore.test.ts` - Added captureError mock

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (434 tests)
- [ ] Verify errors are captured in Sentry (production)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)