### PR TITLE
docs: add .env.example with all environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# ===========================================
+# Kniferoll - Environment Variables
+# ===========================================
+# Copy this file to .env.local and fill in your values
+# cp .env.example .env.local
+
+# -------------------------------------------
+# Supabase (Required)
+# -------------------------------------------
+# For local development, use local Supabase (supabase start)
+# For production, get these from Supabase Dashboard > Settings > API
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_PUBLISHABLE_KEY=your-anon-key
+VITE_API_BASE_URL=http://127.0.0.1:54321
+
+# Service role key for edge functions (from supabase start output)
+SERVICE_ROLE_KEY=your-service-role-key
+
+# -------------------------------------------
+# Stripe (Required for billing)
+# -------------------------------------------
+# Get these from Stripe Dashboard > Developers > API keys
+# Use test keys (pk_test_/sk_test_) for development
+VITE_STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_PRO_PRICE_ID=price_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# -------------------------------------------
+# Sentry (Optional - for error tracking)
+# -------------------------------------------
+# Get the DSN from Sentry project settings
+VITE_SENTRY_DSN=https://...@sentry.io/...
+VITE_SENTRY_ENV=development
+
+# -------------------------------------------
+# Zoho Desk (Optional - for support tickets)
+# -------------------------------------------
+# Get these from Zoho API Console
+ZOHO_CLIENT_ID=1000....
+ZOHO_CLIENT_SECRET=...
+ZOHO_REFRESH_TOKEN=1000....
+ZOHO_ORG_ID=...
+ZOHO_DEPARTMENT_ID=...

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ jspm_packages/
 # Environment files
 .env
 .env.*
+!.env.example
 .env.local
 .env.*.local
 


### PR DESCRIPTION
Fixes #34

## What does this PR do?

Adds a `.env.example` file at the project root documenting all required and optional environment variables for the project.

## Variables documented

**Required - Supabase:**
- `VITE_SUPABASE_URL`
- `VITE_SUPABASE_PUBLISHABLE_KEY`
- `VITE_API_BASE_URL`
- `SERVICE_ROLE_KEY`

**Required - Stripe (for billing):**
- `VITE_STRIPE_PUBLISHABLE_KEY`
- `STRIPE_SECRET_KEY`
- `STRIPE_PRO_PRICE_ID`
- `STRIPE_WEBHOOK_SECRET`

**Optional - Sentry:**
- `VITE_SENTRY_DSN`
- `VITE_SENTRY_ENV`

**Optional - Zoho Desk:**
- `ZOHO_CLIENT_ID`
- `ZOHO_CLIENT_SECRET`
- `ZOHO_REFRESH_TOKEN`
- `ZOHO_ORG_ID`
- `ZOHO_DEPARTMENT_ID`

## Type of change

- [x] Documentation

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [x] `.env.example` is not gitignored (added exception `!.env.example`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)