### PR TITLE
feat: wire up user avatar menu links to settings sections

### DIFF
--- a/apps/web/src/components/auth/UserAvatarMenu.tsx
+++ b/apps/web/src/components/auth/UserAvatarMenu.tsx
@@ -195,7 +195,7 @@ export function UserAvatarMenu({ kitchenId, onInvite }: UserAvatarMenuProps) {
             {/* Account items */}
             <button
               onClick={() => {
-                // TODO: navigate to account settings
+                navigate("/settings", { state: { section: "personal" } });
                 setUserMenuOpen(false);
               }}
               className={menuItemStyles}
@@ -219,7 +219,7 @@ export function UserAvatarMenu({ kitchenId, onInvite }: UserAvatarMenuProps) {
             </button>
             <button
               onClick={() => {
-                // TODO: navigate to billing
+                navigate("/settings", { state: { section: "billing" } });
                 setUserMenuOpen(false);
               }}
               className={menuItemStyles}
@@ -243,7 +243,7 @@ export function UserAvatarMenu({ kitchenId, onInvite }: UserAvatarMenuProps) {
             </button>
             <button
               onClick={() => {
-                // TODO: navigate to help
+                navigate("/settings", { state: { section: "support" } });
                 setUserMenuOpen(false);
               }}
               className={menuItemStyles}

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useDarkModeContext } from "@/context";
 import { useAuthStore } from "@/stores";
 import { useKitchens, useHeaderConfig } from "@/hooks";
@@ -57,13 +57,26 @@ function SupportSettingsPanel() {
 
 export function Settings() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { isDark } = useDarkModeContext();
   const { user } = useAuthStore();
   const { kitchens, loading: kitchensLoading } = useKitchens(user?.id);
 
-  const [activeSection, setActiveSection] = useState<string>("personal");
+  // Get initial section from navigation state (e.g., from UserAvatarMenu)
+  const locationSection = (location.state as { section?: string } | null)
+    ?.section;
+  const [activeSection, setActiveSection] = useState<string>(
+    locationSection || "personal"
+  );
   const [memberships, setMemberships] = useState<KitchenMember[]>([]);
   const [membershipsLoading, setMembershipsLoading] = useState(true);
+
+  // Update section when navigating with state (e.g., from UserAvatarMenu)
+  useEffect(() => {
+    if (locationSection) {
+      setActiveSection(locationSection);
+    }
+  }, [locationSection]);
 
   // Fetch memberships for all kitchens
   useEffect(() => {


### PR DESCRIPTION
Fixes #51

## What does this PR do?

Wires up the user avatar menu items (Account Settings, Billing, Help & Support) to actually navigate to the correct settings sections. Previously these buttons just closed the menu without navigating anywhere (had TODO comments).

## Changes

- **UserAvatarMenu.tsx**: Updated onClick handlers for Account Settings, Billing, and Help & Support to navigate to `/settings` with the appropriate section in location state
- **Settings.tsx**: Added `useLocation` hook to read the initial section from navigation state, so clicking menu items takes users directly to the correct tab

## User Flow

1. User clicks avatar menu
2. Clicks "Help & Support" (or Account Settings, or Billing)
3. Navigates to Settings page with Support tab active

Users can now reach support in ≤2 taps from main navigation (avatar → Help & Support).

## Type of change

- [x] New feature

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (434 tests)
- [x] Changes tested manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)