### PR TITLE
feat: refresh user store after profile update

### DIFF
--- a/apps/web/src/components/settings/PersonalSettingsTab.tsx
+++ b/apps/web/src/components/settings/PersonalSettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useDarkModeContext } from "@/context";
 import { supabase } from "@/lib";
+import { useAuthStore } from "@/stores";
 import { Alert } from "../ui/Alert";
 import { Button } from "../ui/Button";
 import { FormInput } from "../ui/FormInput";
@@ -24,6 +25,7 @@ function getUserDisplayName(user: User): string {
 
 export function PersonalSettingsTab({ user }: PersonalSettingsTabProps) {
   const { isDark, toggle } = useDarkModeContext();
+  const { refreshUser } = useAuthStore();
   const originalName = getUserDisplayName(user);
   const [displayName, setDisplayName] = useState(originalName);
   const [saving, setSaving] = useState(false);
@@ -52,6 +54,10 @@ export function PersonalSettingsTab({ user }: PersonalSettingsTabProps) {
       });
 
       if (updateError) throw updateError;
+
+      // Refresh the user in the auth store to update UI everywhere
+      await refreshUser();
+
       setSuccess("Settings saved successfully");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to update profile");

--- a/apps/web/src/test/utils/providers.tsx
+++ b/apps/web/src/test/utils/providers.tsx
@@ -44,6 +44,9 @@ function getTestAuthStore() {
       signIn: vi.fn(() => Promise.resolve({ error: undefined })),
       signUp: vi.fn(() => Promise.resolve({ error: undefined })),
       signOut: vi.fn(() => Promise.resolve()),
+      resetPasswordForEmail: vi.fn(() => Promise.resolve({ error: undefined })),
+      updatePassword: vi.fn(() => Promise.resolve({ error: undefined })),
+      refreshUser: vi.fn(() => Promise.resolve()),
     };
   }
   return {
@@ -55,6 +58,9 @@ function getTestAuthStore() {
     signIn: vi.fn(() => Promise.resolve({ error: undefined })),
     signUp: vi.fn(() => Promise.resolve({ error: undefined })),
     signOut: vi.fn(() => Promise.resolve()),
+    resetPasswordForEmail: vi.fn(() => Promise.resolve({ error: undefined })),
+    updatePassword: vi.fn(() => Promise.resolve({ error: undefined })),
+    refreshUser: vi.fn(() => Promise.resolve()),
   };
 }
 


### PR DESCRIPTION
Fixes #46

## What does this PR do?

Ensures the user's display name is refreshed in the auth store after updating it in Personal Settings. This fix ensures:

- **Avatar menu**: Shows updated name immediately after saving
- **Kitchen members list**: Shows correct name for the current user
- **Personal Settings**: Name field reflects the saved value

The fix calls `refreshUser()` after a successful `updateUser()` call, which fetches fresh user data from Supabase and updates the auth store.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [x] Changes tested manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)