### PR TITLE
fix: replace deprecated apple-mobile-web-app-capable meta tag

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,7 +11,7 @@
     <meta name="description" content="Kitchen prep management made simple" />
 
     <!-- iOS PWA: edge-to-edge display with translucent status bar -->
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <!-- Theme color for status bar - updated dynamically by useDarkMode hook -->
     <meta name="theme-color" content="#fffbeb" />


### PR DESCRIPTION
## What does this PR do?

Replaces the deprecated `apple-mobile-web-app-capable` meta tag with the standardized `mobile-web-app-capable` variant to eliminate console warnings on the login page.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [x] Changes tested manually

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)