### PR TITLE
Fix password reset flow and add change password in Settings

### DIFF
--- a/apps/web/src/components/settings/PersonalSettingsTab.tsx
+++ b/apps/web/src/components/settings/PersonalSettingsTab.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { useDarkModeContext } from "@/context";
-import { supabase } from "@/lib";
+import { supabase, validatePassword, validatePasswordMatch } from "@/lib";
 import { useAuthStore } from "@/stores";
 import { Alert } from "../ui/Alert";
 import { Button } from "../ui/Button";
 import { FormInput } from "../ui/FormInput";
+import { PasswordRequirements } from "../ui/PasswordRequirements";
 import { SettingsSection } from "../ui/SettingsSection";
 import type { User } from "@supabase/supabase-js";
 
@@ -25,12 +26,20 @@ function getUserDisplayName(user: User): string {
 
 export function PersonalSettingsTab({ user }: PersonalSettingsTabProps) {
   const { isDark, toggle } = useDarkModeContext();
-  const { refreshUser } = useAuthStore();
+  const { refreshUser, updatePassword } = useAuthStore();
   const originalName = getUserDisplayName(user);
   const [displayName, setDisplayName] = useState(originalName);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+
+  // Password change state
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const [passwordSuccess, setPasswordSuccess] = useState("");
+  const [changingPassword, setChangingPassword] = useState(false);
 
   const hasChanges = displayName !== originalName;
 
@@ -63,6 +72,64 @@ export function PersonalSettingsTab({ user }: PersonalSettingsTabProps) {
       setError(err instanceof Error ? err.message : "Failed to update profile");
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handlePasswordChange = async () => {
+    setPasswordError("");
+    setPasswordSuccess("");
+
+    // Validate current password is provided
+    if (!currentPassword) {
+      setPasswordError("Current password is required");
+      return;
+    }
+
+    // Validate new password meets requirements
+    const passwordValidation = validatePassword(newPassword);
+    if (!passwordValidation.isValid) {
+      setPasswordError(passwordValidation.error || "Invalid password");
+      return;
+    }
+
+    // Validate passwords match
+    const matchValidation = validatePasswordMatch(newPassword, confirmPassword);
+    if (!matchValidation.isValid) {
+      setPasswordError(matchValidation.error || "Passwords do not match");
+      return;
+    }
+
+    setChangingPassword(true);
+
+    try {
+      // Verify current password by attempting to sign in
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: user.email || "",
+        password: currentPassword,
+      });
+
+      if (signInError) {
+        setPasswordError("Current password is incorrect");
+        return;
+      }
+
+      // Update to new password
+      const result = await updatePassword(newPassword);
+
+      if (result.error) {
+        setPasswordError(result.error);
+        return;
+      }
+
+      // Clear form and show success
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setPasswordSuccess("Password updated successfully");
+    } catch {
+      setPasswordError("Failed to update password. Please try again.");
+    } finally {
+      setChangingPassword(false);
     }
   };
 
@@ -137,6 +204,62 @@ export function PersonalSettingsTab({ user }: PersonalSettingsTabProps) {
               }`}
             />
           </button>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title="Security">
+        <div className="space-y-4">
+          <div
+            className={`p-3 rounded-lg text-sm ${
+              isDark
+                ? "bg-amber-900/30 text-amber-200 border border-amber-700/50"
+                : "bg-amber-50 text-amber-800 border border-amber-200"
+            }`}
+          >
+            Changing your password will sign you out of all other devices.
+          </div>
+
+          {passwordError && <Alert variant="error">{passwordError}</Alert>}
+          {passwordSuccess && <Alert variant="success">{passwordSuccess}</Alert>}
+
+          <FormInput
+            label="Current Password"
+            type="password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            placeholder="Enter your current password"
+          />
+
+          <div>
+            <FormInput
+              label="New Password"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="Enter your new password"
+            />
+            <div className="mt-2">
+              <PasswordRequirements password={newPassword} />
+            </div>
+          </div>
+
+          <FormInput
+            label="Confirm New Password"
+            type="password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Confirm your new password"
+          />
+
+          <div className="pt-2">
+            <Button
+              variant="primary"
+              onClick={handlePasswordChange}
+              disabled={changingPassword || !currentPassword || !newPassword || !confirmPassword}
+            >
+              {changingPassword ? "Changing..." : "Change Password"}
+            </Button>
+          </div>
         </div>
       </SettingsSection>
     </div>

--- a/apps/web/src/test/unit/stores/authStore.test.ts
+++ b/apps/web/src/test/unit/stores/authStore.test.ts
@@ -51,6 +51,7 @@ describe("authStore", () => {
       session: null,
       loading: true,
       initialized: false,
+      pendingPasswordReset: false,
     });
   });
 

--- a/apps/web/src/test/utils/mocks.ts
+++ b/apps/web/src/test/utils/mocks.ts
@@ -314,6 +314,7 @@ export const createMockAuthStore = (overrides = {}) => ({
   session: null,
   loading: false,
   initialized: true,
+  pendingPasswordReset: false,
   initialize: vi.fn(),
   signIn: vi.fn(() => Promise.resolve({ error: undefined })),
   signUp: vi.fn(() => Promise.resolve({ error: undefined })),
@@ -321,6 +322,7 @@ export const createMockAuthStore = (overrides = {}) => ({
   resetPasswordForEmail: vi.fn(() => Promise.resolve({ error: undefined })),
   updatePassword: vi.fn(() => Promise.resolve({ error: undefined })),
   refreshUser: vi.fn(() => Promise.resolve()),
+  clearPendingPasswordReset: vi.fn(),
   ...overrides,
 });
 

--- a/apps/web/src/test/utils/providers.tsx
+++ b/apps/web/src/test/utils/providers.tsx
@@ -40,6 +40,7 @@ function getTestAuthStore() {
       session: defaultMockData.session,
       loading: false,
       initialized: true,
+      pendingPasswordReset: false,
       initialize: vi.fn(),
       signIn: vi.fn(() => Promise.resolve({ error: undefined })),
       signUp: vi.fn(() => Promise.resolve({ error: undefined })),
@@ -47,6 +48,7 @@ function getTestAuthStore() {
       resetPasswordForEmail: vi.fn(() => Promise.resolve({ error: undefined })),
       updatePassword: vi.fn(() => Promise.resolve({ error: undefined })),
       refreshUser: vi.fn(() => Promise.resolve()),
+      clearPendingPasswordReset: vi.fn(),
     };
   }
   return {
@@ -54,6 +56,7 @@ function getTestAuthStore() {
     session: null,
     loading: false,
     initialized: true,
+    pendingPasswordReset: false,
     initialize: vi.fn(),
     signIn: vi.fn(() => Promise.resolve({ error: undefined })),
     signUp: vi.fn(() => Promise.resolve({ error: undefined })),
@@ -61,6 +64,7 @@ function getTestAuthStore() {
     resetPasswordForEmail: vi.fn(() => Promise.resolve({ error: undefined })),
     updatePassword: vi.fn(() => Promise.resolve({ error: undefined })),
     refreshUser: vi.fn(() => Promise.resolve()),
+    clearPendingPasswordReset: vi.fn(),
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes password reset flow (issue #80) and adds change password functionality to Settings (issue #84).

### Issue #80: Fix password reset link behavior
- Detect `PASSWORD_RECOVERY` event in `onAuthStateChange`
- Redirect to `/reset-password` when user clicks reset link in email
- Previously, users were logged in directly without being prompted to set a new password

### Issue #84: Add change password functionality
- Add Security section to Personal Settings tab
- Current password verification before allowing change
- Interactive password requirements UI
- Info banner about signing out other devices

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds  
- [x] `pnpm test` passes
- [x] Self-reviewed the code

Closes #80
Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)