### PR TITLE
fix: add deployment comment for create-portal-session

### DIFF
--- a/supabase/functions/create-portal-session/index.ts
+++ b/supabase/functions/create-portal-session/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Create Portal Session Edge Function
+ *
+ * Creates Stripe Billing Portal sessions for subscription management.
+ *
+ * DEPLOYMENT:
+ * This function must be deployed with --no-verify-jwt flag since we handle
+ * JWT verification manually to extract user info:
+ *
+ *   supabase functions deploy create-portal-session --no-verify-jwt
+ */
+
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
 


### PR DESCRIPTION
Fixes #89

## What does this PR do?

Adds deployment documentation comment to `create-portal-session` edge function specifying that it must be deployed with `--no-verify-jwt` flag.

The function handles JWT verification manually (extracts auth header and calls `supabase.auth.getUser()`), but Supabase's gateway-level JWT verification blocks requests before they reach the function code. Same issue we fixed for `create-support-ticket`.

**After merging, redeploy with:**
```bash
supabase functions deploy create-portal-session --no-verify-jwt
```

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [ ] Changes tested manually (requires deployment to verify)