### PR TITLE
feat: enable promotion codes on Stripe checkout

### DIFF
--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -152,6 +152,7 @@ Deno.serve(async (req: Request) => {
           quantity: 1,
         },
       ],
+      allow_promotion_codes: true,
       success_url: body.successUrl,
       cancel_url: body.cancelUrl,
       metadata: {


### PR DESCRIPTION
## What does this PR do?

Enables the promotion code field on Stripe Checkout by adding `allow_promotion_codes: true` to the checkout session creation.

Users will now see an "Add promotion code" link on the checkout page.

## Type of change

- [ ] Bug fix
- [x] New feature

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [ ] Changes tested manually (requires deployment)

**After merging, redeploy:**
```bash
supabase functions deploy create-checkout-session --no-verify-jwt
```