### PR TITLE
fix: stripe subscription and checkout improvements

### DIFF
--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -152,6 +152,7 @@ Deno.serve(async (req: Request) => {
           quantity: 1,
         },
       ],
+      allow_promotion_codes: true,
       success_url: body.successUrl,
       cancel_url: body.cancelUrl,
       metadata: {

--- a/supabase/functions/stripe-webhooks/index.ts
+++ b/supabase/functions/stripe-webhooks/index.ts
@@ -58,6 +58,12 @@ Deno.serve(async (req: Request) => {
 
     // Handle specific event types
     switch (event.type) {
+      case "customer.subscription.created": {
+        const subscription = event.data.object as Stripe.Subscription;
+        await handleSubscriptionUpdate(subscription);
+        break;
+      }
+
       case "customer.subscription.updated": {
         const subscription = event.data.object as Stripe.Subscription;
         await handleSubscriptionUpdate(subscription);

--- a/supabase/functions/stripe-webhooks/index.ts
+++ b/supabase/functions/stripe-webhooks/index.ts
@@ -1,3 +1,15 @@
+/**
+ * Stripe Webhooks Edge Function
+ *
+ * Handles Stripe webhook events for subscription management.
+ *
+ * DEPLOYMENT:
+ * This function must be deployed with --no-verify-jwt flag since Stripe
+ * uses its own signature verification (not JWTs):
+ *
+ *   supabase functions deploy stripe-webhooks --no-verify-jwt
+ */
+
 import Stripe from "stripe";
 
 const stripe = new Stripe(Deno.env.get("STRIPE_SECRET_KEY") as string);


### PR DESCRIPTION
## What does this PR do?

1. **Handle `customer.subscription.created` webhook** - New subscriptions now properly activate user accounts. Previously only `updated` was handled, so first-time subscribers stayed on free.

2. **Enable promotion codes on checkout** - Adds `allow_promotion_codes: true` so users can enter coupon codes.

3. **Add deployment comment to stripe-webhooks** - Documents the `--no-verify-jwt` requirement.

## Type of change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [ ] Changes tested manually

**After merging, redeploy both functions:**
```bash
supabase functions deploy stripe-webhooks --no-verify-jwt
supabase functions deploy create-checkout-session --no-verify-jwt
```