### PR TITLE
fix: add retry logic for chunk load failures

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Suspense, lazy } from "react";
+import { useEffect, Suspense } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -11,60 +11,61 @@ import { Analytics } from "@vercel/analytics/react";
 import { useAuthStore } from "./stores/authStore";
 import { PublicLayout, AppLayout } from "./layouts";
 import { ScrollToTop } from "./components";
+import { lazyWithRetry } from "./lib";
 
-// Lazy load pages
-const Landing = lazy(() =>
+// Lazy load pages with retry on chunk load failure
+const Landing = lazyWithRetry(() =>
   import("./pages/Landing").then((m) => ({ default: m.Landing }))
 );
-const Login = lazy(() =>
+const Login = lazyWithRetry(() =>
   import("./pages/Login").then((m) => ({ default: m.Login }))
 );
-const Signup = lazy(() =>
+const Signup = lazyWithRetry(() =>
   import("./pages/Signup").then((m) => ({ default: m.Signup }))
 );
-const InviteJoin = lazy(() =>
+const InviteJoin = lazyWithRetry(() =>
   import("./pages/InviteJoin").then((m) => ({ default: m.InviteJoin }))
 );
-const JoinWithCode = lazy(() =>
+const JoinWithCode = lazyWithRetry(() =>
   import("./pages/JoinWithCode").then((m) => ({ default: m.JoinWithCode }))
 );
-const Dashboard = lazy(() =>
+const Dashboard = lazyWithRetry(() =>
   import("./pages/Dashboard").then((m) => ({ default: m.Dashboard }))
 );
-const KitchenDashboard = lazy(() =>
+const KitchenDashboard = lazyWithRetry(() =>
   import("./pages/KitchenDashboard").then((m) => ({
     default: m.KitchenDashboard,
   }))
 );
-const StationView = lazy(() =>
+const StationView = lazyWithRetry(() =>
   import("./pages/StationView").then((m) => ({ default: m.StationView }))
 );
-const Settings = lazy(() =>
+const Settings = lazyWithRetry(() =>
   import("./pages/Settings").then((m) => ({
     default: m.Settings,
   }))
 );
-const TermsOfService = lazy(() =>
+const TermsOfService = lazyWithRetry(() =>
   import("./pages/TermsOfService").then((m) => ({
     default: m.TermsOfService,
   }))
 );
-const PrivacyPolicy = lazy(() =>
+const PrivacyPolicy = lazyWithRetry(() =>
   import("./pages/PrivacyPolicy").then((m) => ({
     default: m.PrivacyPolicy,
   }))
 );
-const ForgotPassword = lazy(() =>
+const ForgotPassword = lazyWithRetry(() =>
   import("./pages/ForgotPassword").then((m) => ({
     default: m.ForgotPassword,
   }))
 );
-const ResetPassword = lazy(() =>
+const ResetPassword = lazyWithRetry(() =>
   import("./pages/ResetPassword").then((m) => ({
     default: m.ResetPassword,
   }))
 );
-const VerifyEmail = lazy(() =>
+const VerifyEmail = lazyWithRetry(() =>
   import("./pages/VerifyEmail").then((m) => ({
     default: m.VerifyEmail,
   }))

--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from "./auth";
 export * from "./dateUtils";
 export * from "./entitlements";
+export * from "./lazyWithRetry";
 export * from "./sentry";
 export * from "./storage";
 export * from "./stripe";

--- a/apps/web/src/lib/lazyWithRetry.ts
+++ b/apps/web/src/lib/lazyWithRetry.ts
@@ -1,0 +1,33 @@
+import { lazy } from "react";
+import type { ComponentType } from "react";
+
+/**
+ * Wrapper around React.lazy that handles chunk load failures.
+ * When a chunk fails to load (common after deploys with stale cache),
+ * it reloads the page once to get fresh chunks.
+ */
+export function lazyWithRetry<T extends ComponentType<unknown>>(
+  importFn: () => Promise<{ default: T }>
+): React.LazyExoticComponent<T> {
+  return lazy(async () => {
+    const hasRefreshed = sessionStorage.getItem("chunk-refresh");
+
+    try {
+      const module = await importFn();
+      // Success - clear the refresh flag
+      sessionStorage.removeItem("chunk-refresh");
+      return module;
+    } catch (error) {
+      // If we haven't refreshed yet, try once
+      if (!hasRefreshed) {
+        sessionStorage.setItem("chunk-refresh", "true");
+        window.location.reload();
+        // Return a placeholder while reloading (won't actually render)
+        return { default: (() => null) as unknown as T };
+      }
+
+      // Already refreshed once - throw to show error boundary
+      throw error;
+    }
+  });
+}


### PR DESCRIPTION
## What does this PR do?

Adds `lazyWithRetry` wrapper to handle chunk load failures gracefully.

### Problem
After deployments, users with stale cached HTML try to load chunks that no longer exist (chunk hashes changed). This causes "Importing a module script failed" errors.

### Solution
- `lazyWithRetry` wraps `React.lazy` with automatic retry
- On first failure, reloads the page to get fresh HTML/chunks
- Uses sessionStorage flag to prevent infinite reload loops
- Falls back to error boundary if reload doesn't help

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds