### PR TITLE
fix: SPA routing for direct URL access and 404 page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -45,16 +45,9 @@ const Settings = lazyWithRetry(() =>
     default: m.Settings,
   }))
 );
-const TermsOfService = lazyWithRetry(() =>
-  import("./pages/TermsOfService").then((m) => ({
-    default: m.TermsOfService,
-  }))
-);
-const PrivacyPolicy = lazyWithRetry(() =>
-  import("./pages/PrivacyPolicy").then((m) => ({
-    default: m.PrivacyPolicy,
-  }))
-);
+// Legal pages loaded eagerly for instant access (SEO/compliance critical)
+import { TermsOfService } from "./pages/TermsOfService";
+import { PrivacyPolicy } from "./pages/PrivacyPolicy";
 const ForgotPassword = lazyWithRetry(() =>
   import("./pages/ForgotPassword").then((m) => ({
     default: m.ForgotPassword,
@@ -68,6 +61,11 @@ const ResetPassword = lazyWithRetry(() =>
 const VerifyEmail = lazyWithRetry(() =>
   import("./pages/VerifyEmail").then((m) => ({
     default: m.VerifyEmail,
+  }))
+);
+const NotFound = lazyWithRetry(() =>
+  import("./pages/NotFound").then((m) => ({
+    default: m.NotFound,
   }))
 );
 
@@ -113,7 +111,7 @@ function ErrorFallback({ resetError }: { resetError: () => void }) {
 }
 
 function App() {
-  const { initialize, user, loading } = useAuthStore();
+  const { initialize, loading } = useAuthStore();
 
   useEffect(() => {
     if ("requestIdleCallback" in window) {
@@ -172,11 +170,8 @@ function App() {
               />
             </Route>
 
-            {/* Catch all - redirect to landing or dashboard */}
-            <Route
-              path="*"
-              element={<Navigate to={user ? "/dashboard" : "/"} replace />}
-            />
+            {/* 404 - Page not found */}
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </Suspense>
         <Analytics />

--- a/apps/web/src/pages/NotFound.test.tsx
+++ b/apps/web/src/pages/NotFound.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { NotFound } from "./NotFound";
+
+// Mock stores and context
+vi.mock("@/stores", () => ({
+  useAuthStore: vi.fn(() => ({ user: null })),
+}));
+
+vi.mock("@/context", () => ({
+  useDarkModeContext: vi.fn(() => ({ isDark: false })),
+}));
+
+import { useAuthStore } from "@/stores";
+
+describe("NotFound", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders 404 message", () => {
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId("page-not-found")).toBeInTheDocument();
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(screen.getByText("Page not found")).toBeInTheDocument();
+  });
+
+  it("shows homepage link for unauthenticated users", () => {
+    vi.mocked(useAuthStore).mockReturnValue({ user: null } as ReturnType<typeof useAuthStore>);
+
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Go to Homepage" })).toHaveAttribute("href", "/");
+    expect(screen.queryByRole("link", { name: "Homepage" })).not.toBeInTheDocument();
+  });
+
+  it("shows dashboard link for authenticated users", () => {
+    vi.mocked(useAuthStore).mockReturnValue({ user: { id: "user-123" } } as ReturnType<typeof useAuthStore>);
+
+    render(
+      <MemoryRouter>
+        <NotFound />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Go to Dashboard" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute("href", "/");
+  });
+});

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -9,6 +9,7 @@ export function NotFound() {
 
   return (
     <div
+      data-testid="page-not-found"
       className="min-h-screen flex items-center justify-center px-4 bg-linear-to-br from-amber-50 via-amber-50/80 to-orange-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900"
       style={{
         fontFamily: "'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif",

--- a/apps/web/src/pages/NotFound.tsx
+++ b/apps/web/src/pages/NotFound.tsx
@@ -1,0 +1,63 @@
+import { Link } from "react-router-dom";
+import { useDarkModeContext } from "@/context";
+import { useAuthStore } from "@/stores";
+import { Card } from "@/components/ui/Card";
+
+export function NotFound() {
+  const { isDark } = useDarkModeContext();
+  const { user } = useAuthStore();
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center px-4 bg-linear-to-br from-amber-50 via-amber-50/80 to-orange-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900"
+      style={{
+        fontFamily: "'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif",
+      }}
+    >
+      <div className="w-full max-w-md text-center">
+        <h1
+          className={`text-8xl font-bold mb-4 ${
+            isDark ? "text-slate-700" : "text-amber-200"
+          }`}
+        >
+          404
+        </h1>
+        <h2
+          className={`text-2xl font-semibold mb-2 ${
+            isDark ? "text-white" : "text-slate-900"
+          }`}
+        >
+          Page not found
+        </h2>
+        <p
+          className={`mb-8 ${isDark ? "text-slate-400" : "text-slate-600"}`}
+        >
+          The page you're looking for doesn't exist or has been moved.
+        </p>
+
+        <Card padding="lg">
+          <div className="flex flex-col gap-3">
+            <Link
+              to={user ? "/dashboard" : "/"}
+              className="w-full px-4 py-2.5 bg-amber-600 hover:bg-amber-700 text-white font-medium rounded-lg transition-colors text-center"
+            >
+              {user ? "Go to Dashboard" : "Go to Homepage"}
+            </Link>
+            {user && (
+              <Link
+                to="/"
+                className={`w-full px-4 py-2.5 font-medium rounded-lg transition-colors text-center ${
+                  isDark
+                    ? "bg-slate-700 hover:bg-slate-600 text-white"
+                    : "bg-slate-100 hover:bg-slate-200 text-slate-700"
+                }`}
+              >
+                Homepage
+              </Link>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/test/integration/budgets.ts
+++ b/apps/web/src/test/integration/budgets.ts
@@ -77,7 +77,7 @@ export type BudgetName = keyof typeof RENDER_BUDGETS;
 /**
  * Pages excluded from budget coverage tests (static content, no perf concern)
  */
-export const EXCLUDED_PAGES = ["PrivacyPolicy", "TermsOfService"] as const;
+export const EXCLUDED_PAGES = ["NotFound", "PrivacyPolicy", "TermsOfService"] as const;
 
 /**
  * Get budget for a specific page or interaction.

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with rewrites to serve `index.html` for all routes, fixing direct URL navigation
- Creates a proper 404 page component instead of auto-redirecting
- Eagerly loads TermsOfService and PrivacyPolicy pages for instant access (no loading spinners)

This fixes direct navigation to `/privacy`, `/terms`, and other routes which previously returned 404 from Vercel because the SPA routing wasn't configured.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds  
- [x] `pnpm test` passes

## Context

Google OAuth verification was blocked because https://www.kniferoll.io/privacy returned 404 when accessed directly (only worked when navigating from root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)